### PR TITLE
Update license to include thoughtbot's MIT license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,3 +1,36 @@
+This 18F project is originally based on [thoughtbot's laptop project](https://github.com/thoughtbot/laptop).
+
+
+## thoughtbot's work
+
+[thoughtbot's laptop project](https://github.com/thoughtbot/laptop), and code we retain here from it, is released under the MIT License:
+
+```
+Copyright (c) 2011-2014 thoughtbot, inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+```
+
+## Public domain
+
+18F's contributions to this project are covered by the following:
+
 As a work of the United States Government, this project is in the
 public domain within the United States.
 

--- a/README.md
+++ b/README.md
@@ -154,7 +154,9 @@ The 18F laptop script is based on and inspired by
 
 ### Public domain
 
-This project is in the worldwide [public domain](LICENSE.md). As stated in [CONTRIBUTING](CONTRIBUTING.md):
+thoughtbot's original work remains covered under an [MIT License](https://github.com/thoughtbot/laptop/blob/c997c4fb5a986b22d6c53214d8f219600a4561ee/LICENSE).
+
+18F's work on this project is in the worldwide [public domain](LICENSE.md), as are contributions to our project. As stated in [CONTRIBUTING](CONTRIBUTING.md):
 
 > This project is in the public domain within the United States, and copyright and related rights in the work worldwide are waived through the [CC0 1.0 Universal public domain dedication](https://creativecommons.org/publicdomain/zero/1.0/).
 >


### PR DESCRIPTION
This brings us into what I think is compliance with thoughtbot's MIT license.

Fixes #1.