### PR TITLE
Handle edge case for GitHub.app

### DIFF
--- a/mac
+++ b/mac
@@ -220,5 +220,5 @@ fi
 append_to_file "$HOME/.rvmrc" 'rvm_auto_reload_flag=2'
 
 if [ ! -f "$HOME/.ssh/github_rsa.pub" ]; then
-  open ~/Applications/GitHub.app
+  open ~/Applications/GitHub.app || open /Applications/GitHub.app
 fi


### PR DESCRIPTION
On my laptop, the script failed on the last step because:

1. the key-pair I use for github isn't named github_rsa
2. github.app isn't installed on ~/Applications on my machine

We could get fancy and try to prompt users at the end of the script on whether or not they want to open github.app and create a key-pair. For now, though, this prevents the error by looking for github.app in /Applications if it's not in ~/Applications.