### PR TITLE
Install Bundler globally

### DIFF
--- a/mac
+++ b/mac
@@ -23,7 +23,7 @@ append_to_file() {
     fi
   fi
 
-  if ! grep -Fqs "$text" "$file"; then
+  if ! grep -qs "^$text$" "$file"; then
     printf "\n%s\n" "$text" >> "$file"
   fi
 }
@@ -185,7 +185,7 @@ if ! command -v rbenv >/dev/null; then
     latest_version="$(curl -s https://raw.githubusercontent.com/wayneeseguin/rvm/stable/VERSION)"
     if [ "$local_version" != "$latest_version" ]; then
       fancy_echo 'Upgrading RVM...'
-      rvm get stable --auto-dotfiles --autolibs=enable
+      rvm get stable --auto-dotfiles --autolibs=enable --with-gems="bundler"
     else
       fancy_echo "Already using the latest version of RVM. Skipping..."
     fi
@@ -218,6 +218,7 @@ if [ -f "$HOME/.laptop.local" ]; then
 fi
 
 append_to_file "$HOME/.rvmrc" 'rvm_auto_reload_flag=2'
+append_to_file "$HOME/.rvm/gemsets/global.gems" 'bundler'
 
 brew_tap 'pivotal/tap'
 brew_install_or_upgrade 'cloudfoundry-cli'


### PR DESCRIPTION
RVM stopped shipping with Bundler, which means that if you clone
a repo that uses a `.ruby-gemset`, or if you install a new version
of Ruby, or update to a new version of RVM, Bundler won't be
automatically available, and `bundle install` will fail.

Beginners might not know they can `gem install bundler` to fix the
issue, and even if you did know, having to type that each time is
annoying. Since Bundler is widely used, it makes sense to install
it in the global gemset so that it is available at any time.

RVM provides the  `--with-gems` flag that can be used to install
bundler when installing RVM for the first time, and when updating
RVM. However, there is a bug where using the flag when installing
for the first time will prevent Ruby from being installed.
Therefore, I only enabled the flag for the upgrade scenario.

I also had to fix the append_to_file function to look for exact
string matches. Otherwise, it would treat "rubygems-bundler" as a
match for "bundler" and won't add it to the global gemset.