### PR TITLE
Replace Qt with PhantomJS

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,9 @@ What it sets up
 * [ImageMagick] for cropping and resizing images
 * [MySQL] for storing relational data
 * [Node.js] and [NPM], for running apps and installing JavaScript packages
+* [PhantomJS] for headless website testing
 * [Postgres] for storing relational data
 * [Python 3] for programming software and data analysis
-* [Qt] for headless JavaScript testing via Capybara Webkit
 * [Redis] for storing key-value data
 * [RVM] for managing Ruby versions (includes [Bundler] and the latest [Ruby])
 * [Slack] for communicating with your team
@@ -101,9 +101,9 @@ What it sets up
 [MySQL]: https://www.mysql.com/
 [Node.js]: http://nodejs.org/
 [NPM]: https://www.npmjs.org/
+[PhantomJS]: http://phantomjs.org/
 [Postgres]: http://www.postgresql.org/
 [Python 3]: https://www.python.org/
-[Qt]: http://qt-project.org/
 [Redis]: http://redis.io/
 [Ruby]: https://www.ruby-lang.org/en/
 [RVM]: https://github.com/wayneeseguin/rvm

--- a/mac
+++ b/mac
@@ -155,7 +155,7 @@ fancy_echo 'Restarting redis...'
 brew services restart redis
 
 brew_install_or_upgrade 'imagemagick'
-brew_install_or_upgrade 'qt'
+brew_install_or_upgrade 'phantomjs'
 
 brew_install_or_upgrade 'hub'
 # shellcheck disable=SC2016


### PR DESCRIPTION
Why:
The original reason for including Qt was to provide support for Ruby apps that are using capybara-webkit. However, capybara-webkit will soon require Qt5 to be installed, but Qt5 requires the full Xcode package.

I don't think it's possible to automate the installation of Xcode, and even if it were possible, I wouldn't want to force everyone to download a multi-gigabyte file. Instead, it makes more sense to recommend PhantomJS and Poltergeist (for Ruby apps), which works just as well as capybara-webkit.