### PR TITLE
Only launch GitHub app if not previously installed

### DIFF
--- a/mac
+++ b/mac
@@ -223,6 +223,11 @@ append_to_file "$HOME/.rvm/gemsets/global.gems" 'bundler'
 brew_tap 'pivotal/tap'
 brew_install_or_upgrade 'cloudfoundry-cli'
 
-if [ ! -f "$HOME/.ssh/github_rsa.pub" ]; then
+if app_is_installed 'GitHub'; then
+  fancy_echo "It looks like you've already configured your GitHub SSH keys."
+  fancy_echo "If not, you can do it by signing in to the GitHub app on your Mac."
+elif [ ! -f "$HOME/.ssh/github_rsa.pub" ]; then
   open ~/Applications/GitHub.app
 fi
+
+fancy_echo 'All done!'


### PR DESCRIPTION
Before, the script would determine whether or not to launch GitHub based on the presence of `github_rsa.pub`. This isn't robust since some users might have a GitHub SSH key with a different name, or might not have one even though GitHub app is installed.

The script then tries to launch GitHub app from `~/Applications`, but if the user already has the app in `/Applications`, Brew Cask will not have installed it in `~/Applications`, causing the script to report a failure at the end since it can't find the app.

Instead, we first check to see if the user already has GitHub installed in the `/Applications` directory. If they do, we assume they already set up their keys, and echo a helpful message. Otherwise, that means GitHub was installed via Brew Cask and can be launched without issues.

Closes #23.