### PR TITLE
Update travis config for shellcheck

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: sh
 
 before_script:
-  - sudo add-apt-repository -y "deb http://mirrors.kernel.org/ubuntu utopic main universe"
-  - sudo apt-get -y update
-  - sudo apt-get -y install shellcheck
+  - sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu/ trusty-backports restricted main universe"
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq shellcheck
 
 script:
   - shellcheck mac


### PR DESCRIPTION
The old apt-repository is no longer available so we need to update it to one that provides shellcheck.

I also updated the sudo command to use passwordless mode per the Travis documentation:
http://docs.travis-ci.com/user/customizing-the-build/#Installing-Packages-Using-apt