### PR TITLE
Rename GitHub to GitHub Desktop

### DIFF
--- a/mac
+++ b/mac
@@ -227,7 +227,7 @@ if app_is_installed 'GitHub'; then
   fancy_echo "It looks like you've already configured your GitHub SSH keys."
   fancy_echo "If not, you can do it by signing in to the GitHub app on your Mac."
 elif [ ! -f "$HOME/.ssh/github_rsa.pub" ]; then
-  open ~/Applications/GitHub.app
+  open ~/Applications/GitHub\ Desktop.app
 fi
 
 fancy_echo 'All done!'


### PR DESCRIPTION
The GitHub app for Mac has been renamed "GitHub Desktop.app", which explains why the Cask name was updated. This fix allows the app to be launched when necessary.