### PR TITLE
Skip phantomjs on El Capitan

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ What it sets up
 * [ImageMagick] for cropping and resizing images
 * [MySQL] for storing relational data
 * [Node.js] and [NPM], for running apps and installing JavaScript packages
-* [PhantomJS] for headless website testing
+* [PhantomJS] for headless website testing (unless on El Capitan, due to [this bug](https://github.com/Homebrew/homebrew/issues/42249))
 * [Postgres] for storing relational data
 * [Python 3] for programming software and data analysis
 * [Redis] for storing key-value data

--- a/mac
+++ b/mac
@@ -155,7 +155,10 @@ fancy_echo 'Restarting redis...'
 brew services restart redis
 
 brew_install_or_upgrade 'imagemagick'
-brew_install_or_upgrade 'phantomjs'
+
+if ! sw_vers -productVersion | grep -q "^10\.11"; then
+  brew_install_or_upgrade 'phantomjs'
+fi
 
 brew_install_or_upgrade 'hub'
 # shellcheck disable=SC2016

--- a/mac
+++ b/mac
@@ -156,6 +156,8 @@ brew services restart redis
 
 brew_install_or_upgrade 'imagemagick'
 
+# PhantomJS doesn't support El Capitan yet
+# https://github.com/Homebrew/homebrew/issues/42249
 if ! sw_vers -productVersion | grep -q "^10\.11"; then
   brew_install_or_upgrade 'phantomjs'
 fi


### PR DESCRIPTION
PhantomJS is not yet supported on El Capitan. Therefore, we detect if El Capitan is running, and if not, then we can safely install PhantomJS.

Closes #30.