### PR TITLE
Use n to manage node.js/npm versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ What it sets up
 * [hub] for interacting with the GitHub API
 * [ImageMagick] for cropping and resizing images
 * [MySQL] for storing relational data
-* [Node.js] and [NPM], for running apps and installing JavaScript packages
+* [n] for managing Node.js versions if you do not have [Node.js] already installed (Includes latest [Node.js] and [NPM], for running apps and installing JavaScript packages)
 * [PhantomJS] for headless website testing (unless on El Capitan, due to [this bug](https://github.com/Homebrew/homebrew/issues/42249))
 * [Postgres] for storing relational data
 * [Python 3] for programming software and data analysis
@@ -99,6 +99,7 @@ What it sets up
 [hub]: https://github.com/github/hub
 [ImageMagick]: http://www.imagemagick.org/
 [MySQL]: https://www.mysql.com/
+[n]: https://github.com/tj/n
 [Node.js]: http://nodejs.org/
 [NPM]: https://www.npmjs.org/
 [PhantomJS]: http://phantomjs.org/

--- a/mac
+++ b/mac
@@ -166,7 +166,16 @@ brew_install_or_upgrade 'hub'
 # shellcheck disable=SC2016
 append_to_file "$HOME/.zshrc" 'eval "$(hub alias -s)"'
 
-brew_install_or_upgrade 'node'
+if ! brew_is_installed "node"; then
+  if ! command -v n > /dev/null; then
+    fancy_echo 'Installing n and latest Node.js and NPM...'
+    curl -L http://git.io/n-install | bash -s -- -y latest
+  else
+    fancy_echo 'Updating n...'
+    n-update -y
+  fi
+fi
+
 brew_install_or_upgrade 'python3'
 
 if ! pip3 list | ag "virtualenvwrapper" > /dev/null; then


### PR DESCRIPTION
This will use n, which is a bit simpler to use than nvm, to allow folks to manage node versions. This forgoes installing node/npm directly with homebrew.