### PR TITLE
Add .about.yml

### DIFF
--- a/.about.yml
+++ b/.about.yml
@@ -1,0 +1,116 @@
+---
+# .about.yml project metadata
+#
+# Short name that acts as the project identifier (required)
+name: laptop
+
+# Full proper name of the project (required)
+full_name: Laptop Script
+
+# The type of content in the repo
+# values: app, docs, policy
+type: app
+
+# Describes whether a project team, working group/guild, etc. owns the repo (required)
+# values: guild, working-group, project
+# owner_type:
+
+# Name of the main project repo if this is a sub-repo; name of the working group/guild repo if this is a working group/guild subproject
+# parent:
+
+# Maturity stage of the project (required)
+# values: discovery, alpha, beta, live, sunset, transfer, end
+stage: live
+
+# Description of the project
+description: >
+  A shell script that turns your Mac into an awesome web development
+  machine.
+
+# Tags that describe the project or aspects of the project
+tags:
+- automation
+
+# Should be 'true' if the project has a continuous build (required)
+# values: true, false
+testable: true
+
+# Team members contributing to the project (required)
+# Items:
+# - github: GitHub user name
+#   id: Internal team identifier/user name
+#   role: Team member's role; leads should be designated as 'lead'
+team:
+- github: monfresh
+  id: Moncef Belyamani
+  role: lead
+- github: afeld
+  id: Aidan Feldman
+  role: developer
+
+# Partners for whom the project is developed
+# partners:
+# -
+
+# Organizations or individuals who have adopted the project for their own use
+# Items:
+# - id: The name of the organization or individual
+#   url: A URL to the user's version of the project
+# users:
+# -
+
+# Brief descriptions of significant project developments
+# milestones:
+# -
+
+# Technologies used to build the project
+stack:
+- Bash
+
+# Brief description of the project's outcomes
+impact: >
+  It allows new and current employees to easily set up their laptop with
+  all the tools needed to be productive on day one.
+
+# Services used to supply project status information
+# Items:
+# - name: Name of the service
+#   category: Type of the service
+#   url: URL for detailed information
+#   badge: URL for the status badge
+services:
+- name: Travis
+  category: Continous integration
+  url: https://travis-ci.org/18F/laptop
+  badge: https://travis-ci.org/18F/laptop.svg
+
+# Licenses that apply to the project and/or its components (required)
+# Items by property name pattern:
+#   .*:
+#     name: Name of the license from the Software Package Data Exchange (SPDX): https://spdx.org/licenses/
+#     url: URL for the text of the license
+licenses:
+  thoughtbot-laptop:
+    name: MIT
+    url: https://github.com/thoughtbot/laptop/blob/master/LICENSE
+  18F-laptop:
+    name: CC0
+    url: https://github.com/18F/laptop/blob/master/LICENSE.md
+
+# Blogs or websites associated with project development
+# blog:
+# -
+
+# Links to project artifacts
+# Items:
+# - url: URL for the link
+#   text: Anchor text for the link
+# links:
+# -
+
+# URIs for points-of-contact
+# Items:
+# - url: URI for the link to
+#   text: Anchor text for the link
+# contact:
+# -


### PR DESCRIPTION
Why:
To support the effort of describing our repos via a standard format, which can be consumed by the Project Health Dashboard (https://project-dashboard.18f.gov/default) for example.