### PR TITLE
Update Node.js and Python installation pieces

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,14 +78,14 @@ What it sets up
 * [n] for managing Node.js versions if you do not have [Node.js] already installed (Includes latest [Node.js] and [NPM], for running apps and installing JavaScript packages)
 * [PhantomJS] for headless website testing (unless on El Capitan, due to [this bug](https://github.com/Homebrew/homebrew/issues/42249))
 * [Postgres] for storing relational data
-* [Python 3] for programming software and data analysis
+* [pyenv] for managing Python versions if you do not have [Python] already installed (includes the latest 3.x [Python])
 * [Redis] for storing key-value data
 * [RVM] for managing Ruby versions (includes [Bundler] and the latest [Ruby])
 * [Slack] for communicating with your team
 * [Sublime Text 3] for coding all the things
 * [The Silver Searcher] for finding things in files
-* [Virtualenv] for creating isolated Python environments
-* [Virtualenvwrapper] for extending Virtualenv
+* [Virtualenv] for creating isolated Python environments (via [pyenv] if it is installed)
+* [Virtualenvwrapper] for extending Virtualenv (via [pyenv] if it is installed)
 * [Zsh] as your shell
 
 [Bundler]: http://bundler.io/
@@ -104,7 +104,8 @@ What it sets up
 [NPM]: https://www.npmjs.org/
 [PhantomJS]: http://phantomjs.org/
 [Postgres]: http://www.postgresql.org/
-[Python 3]: https://www.python.org/
+[Python]: https://www.python.org/
+[pyenv]: https://github.com/yyuu/pyenv/
 [Redis]: http://redis.io/
 [Ruby]: https://www.ruby-lang.org/en/
 [RVM]: https://github.com/wayneeseguin/rvm

--- a/mac
+++ b/mac
@@ -166,28 +166,68 @@ brew_install_or_upgrade 'hub'
 # shellcheck disable=SC2016
 append_to_file "$HOME/.zshrc" 'eval "$(hub alias -s)"'
 
+
+fancy_echo 'Checking on Node.js installation...'
+
 if ! brew_is_installed "node"; then
-  if ! command -v n > /dev/null; then
-    fancy_echo 'Installing n and latest Node.js and NPM...'
-    curl -L http://git.io/n-install | bash -s -- -y latest
+  if ! command -v nvm > /dev/null; then
+    if ! command -v n > /dev/null; then
+      fancy_echo 'Installing n and latest Node.js and NPM...'
+      curl -L http://git.io/n-install | bash -s -- -y latest
+    else
+      fancy_echo 'Updating n...'
+      n-update -y
+    fi
   else
-    fancy_echo 'Updating n...'
-    n-update -y
+    fancy_echo 'nvm detected.  Skipping...'
+  fi
+else
+  brew_install_or_upgrade 'node'
+fi
+
+fancy_echo '...Finished Node.js installation checks.'
+
+
+fancy_echo 'Checking on Python installation...'
+
+if ! brew_is_installed "python3"; then
+  brew_install_or_upgrade 'pyenv'
+  # shellcheck disable=SC2016
+  append_to_file "$HOME/.zshrc" 'if which pyenv > /dev/null; then eval "$(pyenv init -)"; fi'
+  brew_install_or_upgrade 'pyenv-virtualenv'
+  # shellcheck disable=SC2016
+  append_to_file "$HOME/.zshrc" 'if which pyenv-virtualenv-init > /dev/null; then eval "$(pyenv virtualenv-init -)"; fi'
+  brew_install_or_upgrade 'pyenv-virtualenvwrapper'
+
+  # pyenv currently doesn't have a convenience version to use, e.g., "latest",
+  # so we check for the latest version against Homebrew instead.
+  latest_python_3="$(brew info python3 | sed -n -e 's/^.*python3: stable //p' | egrep -o "3\.\d+\.\d+")"
+
+  if ! pyenv versions | ag "$latest_python_3" > /dev/null; then
+    pyenv install "$latest_python_3"
+    pyenv global "$latest_python_3"
+    pyenv rehash
+  fi
+else
+  brew_install_or_upgrade 'python3'
+fi
+
+if ! brew_is_installed "pyenv-virtualenvwrapper"; then
+  if ! pip3 list | ag "virtualenvwrapper" > /dev/null; then
+    fancy_echo 'Installing virtualenvwrapper...'
+    pip3 install virtualenvwrapper
+    append_to_file "$HOME/.zshrc" 'export VIRTUALENVWRAPPER_PYTHON=/usr/local/bin/python3'
+    append_to_file "$HOME/.zshrc" 'export VIRTUALENVWRAPPER_VIRTUALENV=/usr/local/bin/virtualenv'
+    append_to_file "$HOME/.zshrc" 'source /usr/local/bin/virtualenvwrapper.sh'
   fi
 fi
 
-brew_install_or_upgrade 'python3'
+fancy_echo '...Finished Python installation checks.'
 
-if ! pip3 list | ag "virtualenvwrapper" > /dev/null; then
-  fancy_echo 'Installing virtualenvwrapper...'
-  pip3 install virtualenvwrapper
-  append_to_file "$HOME/.zshrc" 'export VIRTUALENVWRAPPER_PYTHON=/usr/local/bin/python3'
-  append_to_file "$HOME/.zshrc" 'export VIRTUALENVWRAPPER_VIRTUALENV=/usr/local/bin/virtualenv'
-  append_to_file "$HOME/.zshrc" 'source /usr/local/bin/virtualenvwrapper.sh'
-fi
+
+fancy_echo 'Checking on Ruby installation...'
 
 append_to_file "$HOME/.gemrc" 'gem: --no-document'
-
 
 if ! command -v rbenv >/dev/null; then
   if ! command -v rvm >/dev/null; then
@@ -212,8 +252,10 @@ gem update --system
 gem_install_or_update 'bundler'
 
 fancy_echo "Configuring Bundler ..."
-  number_of_cores=$(sysctl -n hw.ncpu)
-  bundle config --global jobs $((number_of_cores - 1))
+number_of_cores=$(sysctl -n hw.ncpu)
+bundle config --global jobs $((number_of_cores - 1))
+
+fancy_echo '...Finished Ruby installation checks.'
 
 brew_tap 'caskroom/cask'
 


### PR DESCRIPTION
This changeset adds some additional support around installing Node.js and Python and updates the README accordingly.  First, it adds in a bit more backward compatibility support so that if you originally installed Node.js or Python 3.x with the script, you will still receive updates with Homebrew.  The following additional changes are also added:

- Node.js:  A check for nvm is in place, and if it is found the rest of the Node.js install/update processing is skipped since we assume you are managing it yourself.
- Python 3.x:  A check for pyenv now exists; if it Python 3.x is not installed yet and neither is pyenv, pyenv is now installed prior to installing Python 3.x.
- Python 3.x:  A check for the pyenv virtualenvwrapper plugin is now in place as well before installing virtualenvwrapper directly.

These changes for Python provide some additional version management so that you may install multiple versions of Python easily, just like with RVM/rbenv for Ruby.