### PR TITLE
Prefer community Cloud Foundry release over Pivotal's

### DIFF
--- a/mac
+++ b/mac
@@ -234,8 +234,8 @@ fi
 append_to_file "$HOME/.rvmrc" 'rvm_auto_reload_flag=2'
 append_to_file "$HOME/.rvm/gemsets/global.gems" 'bundler'
 
-brew_tap 'pivotal/tap'
-brew_install_or_upgrade 'cloudfoundry-cli'
+brew_tap 'cloudfoundry/homebrew-tap'
+brew_install_or_upgrade 'cf-cli'
 
 if app_is_installed 'GitHub'; then
   fancy_echo "It looks like you've already configured your GitHub SSH keys."

--- a/mac
+++ b/mac
@@ -234,6 +234,9 @@ fi
 append_to_file "$HOME/.rvmrc" 'rvm_auto_reload_flag=2'
 append_to_file "$HOME/.rvm/gemsets/global.gems" 'bundler'
 
+if brew_is_installed 'cloudfoundry-cli'; then
+  brew uninstall cloudfoundry-cli
+fi
 brew_tap 'cloudfoundry/homebrew-tap'
 brew_install_or_upgrade 'cf-cli'
 


### PR DESCRIPTION
Pivotal's CLI version sometimes lags the community version, which is what we prefer people use in any case to avoid any implicit dependency on a commercial vendor.