### PR TITLE
.about.yml is invalid - set owner_type: project

### DIFF
--- a/.about.yml
+++ b/.about.yml
@@ -13,7 +13,7 @@ type: app
 
 # Describes whether a project team, working group/guild, etc. owns the repo (required)
 # values: guild, working-group, project
-# owner_type:
+owner_type: project
 
 # Name of the main project repo if this is a sub-repo; name of the working group/guild repo if this is a working group/guild subproject
 # parent:


### PR DESCRIPTION
Questions? You can read more about the spec here: https://github.com/18F/about_yml
Is this pull incorrect? File an issue at https://github.com/sharms/meta-machine