### PR TITLE
Run `brew doctor` after `brew update`

### DIFF
--- a/mac
+++ b/mac
@@ -134,6 +134,9 @@ fi
 fancy_echo "Updating Homebrew formulas ..."
 brew update
 
+fancy_echo "Verifying the Homebrew installation..."
+brew doctor
+
 brew_install_or_upgrade 'git'
 
 brew_install_or_upgrade 'the_silver_searcher'


### PR DESCRIPTION
**Why**: To make sure the system is ready to brew before installing or upgrading tools. This can catch errors due to upgrading OS X when Homebrew had previously been installed, for example.