### PR TITLE
Use `brew bundle` instead of custom functions

### DIFF
--- a/.laptop.local
+++ b/.laptop.local
@@ -1,12 +1,18 @@
 #!/bin/sh
 
-# brew_cask_install 'atom'
-# brew_cask_install 'firefox'
-# brew_cask_install 'iterm2'
+fancy_echo "Running your customizations from ~/.laptop.local ..."
 
-# brew_install_or_upgrade 'vim'
-# brew_install_or_upgrade 'ctags'
-# brew_install_or_upgrade 'tmux'
-# brew_install_or_upgrade 'reattach-to-user-namespace'
+brew bundle --file=- <<EOF
+cask 'atom'
+cask 'firefox'
+cask 'iterm2'
 
-# brew_install_or_upgrade 'go' && append_to_file "$HOME/.zshrc" 'export PATH="$PATH:/usr/local/opt/go/libexec/bin"'
+brew 'vim'
+brew 'ctags'
+brew 'tmux'
+brew 'reattach-to-user-namespace'
+
+brew 'go'
+EOF
+
+append_to_file "$HOME/.zshrc" 'export PATH="$PATH:/usr/local/opt/go/libexec/bin"'

--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,30 @@
+cask_args appdir: '/Applications'
+
+brew 'git'
+
+brew 'the_silver_searcher'
+
+tap 'homebrew/services'
+
+brew 'postgresql'
+
+brew 'mysql'
+
+brew 'redis'
+
+brew 'imagemagick'
+
+brew 'phantomjs'
+
+brew 'hub'
+
+tap 'cloudfoundry/homebrew-tap'
+brew 'cf-cli'
+
+tap 'caskroom/cask'
+tap 'caskroom/versions'
+cask 'cloud'
+cask 'flux'
+cask 'github-desktop'
+cask 'slack'
+cask 'sublime-text3'

--- a/README.md
+++ b/README.md
@@ -29,12 +29,13 @@ keyboard shortcut for invoking Spotlight is `command-Space`. Once Spotlight
 is up, just start typing the first few letters of the app you are looking for,
 and once it appears, press `return` to launch it.
 
-In your Terminal window, copy and paste each of these two commands one at a
-time, then press `return` after each one to download and execute the
-script, respectively:
+In your Terminal window, copy and paste each of these three commands one at a
+time, then press `return` after each one. The first two commands download the
+files the script needs to run, and the third command executes the script.
 
 ```sh
 curl --remote-name https://raw.githubusercontent.com/18F/laptop/master/mac
+curl --remote-name https://raw.githubusercontent.com/18F/laptop/master/Brewfile
 bash mac 2>&1 | tee ~/laptop.log
 ```
 The [script](https://github.com/18F/laptop/blob/master/mac) itself is
@@ -47,7 +48,7 @@ If you don't already have it installed, GitHub for Mac will launch
 automatically at the end of the script so you can set up everything you'll
 need to push code to GitHub.
 
-Once the script is done, make sure to quit and relaunch Terminal.
+**Once the script is done, make sure to quit and relaunch Terminal.**
 
 More [detailed instructions with a video][video] are available in the Wiki.
 
@@ -58,10 +59,8 @@ Debugging
 ---------
 
 Your last Laptop run will be saved to `~/laptop.log`. Read through it to see if
-you can debug the issue yourself. If not, copy the lines where the script
-failed into a [new GitHub
-Issue](https://github.com/18F/laptop/issues/new) for us. Or, attach the
-whole log file as an attachment.
+you can debug the issue yourself. If not, copy and paste the entire log into a
+[new GitHub Issue](https://github.com/18F/laptop/issues/new) for us.
 
 What it sets up
 ---------------
@@ -96,7 +95,7 @@ What it sets up
 [GitHub Desktop]: https://desktop.github.com/
 [Homebrew]: http://brew.sh/
 [Homebrew Cask]: http://caskroom.io/
-[Homebrew Services]: https://github.com/gapple/homebrew-services
+[Homebrew Services]: https://github.com/Homebrew/homebrew-services
 [hub]: https://github.com/github/hub
 [ImageMagick]: http://www.imagemagick.org/
 [MySQL]: https://www.mysql.com/
@@ -120,13 +119,22 @@ What it sets up
 It should take less than 15 minutes to install (depends on your machine and
 internet connection).
 
-Customize in `~/.laptop.local`
-------------------------------
+Customize in `~/.laptop.local` and `Brewfile`
+---------------------------------------------
 
 Your `~/.laptop.local` is run at the end of the `mac` script.
 Put your customizations there. This repo already contains a `.laptop.local`
-you can use to get started. It lets you install the following tools
-(commented out by default):
+you can use to get started.
+
+```sh
+# Go to your OS X user's root directory
+cd ~
+
+# Download the sample file to your computer
+curl --remote-name https://raw.githubusercontent.com/18F/laptop/master/.laptop.local
+```
+
+It lets you install the following tools:
 
 * [Atom] - GitHub's open source text editor
 * [Exuberant Ctags] for indexing files for vim tab completion
@@ -149,29 +157,62 @@ For example:
 ```sh
 #!/bin/sh
 
-# brew_cask_install 'atom'
-# brew_cask_install 'firefox'
-brew_cask_install 'iterm2'
+fancy_echo "Running your customizations from ~/.laptop.local ..."
 
-# brew_install_or_upgrade 'vim'
-# brew_install_or_upgrade 'ctags'
-# brew_install_or_upgrade 'tmux'
-# brew_install_or_upgrade 'reattach-to-user-namespace'
+brew bundle --file=- <<EOF
+cask 'atom'
+cask 'firefox'
+cask 'iterm2'
+
+brew 'vim'
+brew 'ctags'
+brew 'tmux'
+brew 'reattach-to-user-namespace'
+
+brew 'go'
+EOF
+
+append_to_file "$HOME/.zshrc" 'export PATH="$PATH:/usr/local/opt/go/libexec/bin"'
 ```
 
 Write your customizations such that they can be run safely more than once.
 See the `mac` script for examples.
 
-Laptop functions such as `fancy_echo`, `brew_install_or_upgrade`,
-`gem_install_or_update`, and `brew_cask_install` can be used in your
-`~/.laptop.local`.
+Laptop functions such as `fancy_echo` and `gem_install_or_update` can be used
+in your `~/.laptop.local`.
 
-```sh
-# Go to your OS X user's root directory
-cd ~
+Editing the `Brewfile`
+----------------------
+Most of what the script installs is listed in the `Brewfile`. If you don't want
+the script to install certain tools, you can remove them from the `Brewfile`.
 
-# Download the sample file to your computer
-curl --remote-name https://raw.githubusercontent.com/18F/laptop/master/.laptop.local
+
+How to manage background services (Redis, Postgres, MySQL)
+----------------------------------------------------------
+The script does not automatically launch these services after installation
+because you might not need or want them to be running. With Homebrew Services,
+starting, stopping, or restarting these services is as easy as:
+
+```
+brew services start|stop|restart [name of service]
+```
+
+For example:
+
+```
+brew services start redis
+```
+
+To see a list of all installed services:
+
+```
+brew services list
+```
+
+To start all services at once:
+
+```
+brew services start --all
 ```
 
 Credits

--- a/mac
+++ b/mac
@@ -52,37 +52,8 @@ case "$SHELL" in
     ;;
 esac
 
-brew_install_or_upgrade() {
-  if brew_is_installed "$1"; then
-    if brew_is_upgradable "$1"; then
-      fancy_echo "Upgrading %s ..." "$1"
-      brew upgrade "$@"
-    else
-      fancy_echo "Already using the latest version of %s. Skipping ..." "$1"
-    fi
-  else
-    fancy_echo "Installing %s ..." "$1"
-    brew install "$@"
-  fi
-}
-
 brew_is_installed() {
   brew list -1 | grep -Fqx "$1"
-}
-
-brew_is_upgradable() {
-  ! brew outdated --quiet "$1" >/dev/null
-}
-
-brew_tap_is_installed() {
-  brew tap | ag "$1" > /dev/null
-}
-
-brew_tap() {
-  if ! brew_tap_is_installed "$1"; then
-    fancy_echo "Tapping $1..."
-    brew tap "$1" 2> /dev/null
-  fi
 }
 
 gem_install_or_update() {
@@ -95,29 +66,10 @@ gem_install_or_update() {
   fi
 }
 
-brew_cask_expand_alias() {
-  brew cask info "$1" 2>/dev/null | head -1 | awk '{gsub(/:/, ""); print $1}'
-}
-
-brew_cask_is_installed() {
-  local NAME
-  NAME=$(brew_cask_expand_alias "$1")
-  brew cask list -1 | grep -Fqx "$NAME"
-}
-
 app_is_installed() {
   local app_name
   app_name=$(echo "$1" | cut -d'-' -f1)
   find /Applications -iname "$app_name*" -maxdepth 1 | egrep '.*' > /dev/null
-}
-
-brew_cask_install() {
-  if app_is_installed "$1" || brew_cask_is_installed "$1"; then
-    fancy_echo "$1 is already installed. Skipping..."
-  else
-    fancy_echo "Installing $1..."
-    brew cask install "$@"
-  fi
 }
 
 if ! command -v brew >/dev/null; then
@@ -129,6 +81,13 @@ if ! command -v brew >/dev/null; then
     append_to_file "$HOME/.zshrc" 'export PATH="/usr/local/bin:$PATH"'
 else
   fancy_echo "Homebrew already installed. Skipping ..."
+fi
+
+# Remove brew-cask since it is now installed as part of brew tap caskroom/cask.
+# See https://github.com/caskroom/homebrew-cask/releases/tag/v0.60.0
+if brew_is_installed 'brew-cask'; then
+  brew uninstall --force 'brew-cask'
+  brew untap caskroom/versions
 fi
 
 fancy_echo "Updating Homebrew formulas ..."
@@ -143,34 +102,15 @@ else
   echo "Otherwise, review the Homebrew messages to see if any action is needed."
 fi
 
-brew_install_or_upgrade 'git'
+if brew_is_installed 'cloudfoundry-cli'; then
+  brew uninstall --force cloudfoundry-cli
+fi
 
-brew_install_or_upgrade 'the_silver_searcher'
+fancy_echo "Installing formulas and casks from the Brewfile ..."
+brew bundle
 
-brew_tap 'gapple/services'
-
-brew_install_or_upgrade 'postgresql'
-fancy_echo 'Restarting postgres...'
-brew services restart postgresql
-
-brew_install_or_upgrade 'mysql'
-fancy_echo 'Restarting mysql...'
-brew services restart mysql
-sleep 2
-mysql.server start
-
-brew_install_or_upgrade 'redis'
-fancy_echo 'Restarting redis...'
-brew services restart redis
-
-brew_install_or_upgrade 'imagemagick'
-
-brew_install_or_upgrade 'phantomjs'
-
-brew_install_or_upgrade 'hub'
 # shellcheck disable=SC2016
 append_to_file "$HOME/.zshrc" 'eval "$(hub alias -s)"'
-
 
 fancy_echo 'Checking on Node.js installation...'
 
@@ -187,7 +127,9 @@ if ! brew_is_installed "node"; then
     fancy_echo 'nvm detected.  Skipping...'
   fi
 else
-  brew_install_or_upgrade 'node'
+  brew bundle --file=- <<EOF
+  brew 'node'
+EOF
 fi
 
 fancy_echo '...Finished Node.js installation checks.'
@@ -196,13 +138,15 @@ fancy_echo '...Finished Node.js installation checks.'
 fancy_echo 'Checking on Python installation...'
 
 if ! brew_is_installed "python3"; then
-  brew_install_or_upgrade 'pyenv'
+  brew bundle --file=- <<EOF
+  brew 'pyenv'
+  brew 'pyenv-virtualenv'
+  brew 'pyenv-virtualenvwrapper'
+EOF
   # shellcheck disable=SC2016
   append_to_file "$HOME/.zshrc" 'if which pyenv > /dev/null; then eval "$(pyenv init -)"; fi'
-  brew_install_or_upgrade 'pyenv-virtualenv'
   # shellcheck disable=SC2016
   append_to_file "$HOME/.zshrc" 'if which pyenv-virtualenv-init > /dev/null; then eval "$(pyenv virtualenv-init -)"; fi'
-  brew_install_or_upgrade 'pyenv-virtualenvwrapper'
 
   # pyenv currently doesn't have a convenience version to use, e.g., "latest",
   # so we check for the latest version against Homebrew instead.
@@ -214,7 +158,9 @@ if ! brew_is_installed "python3"; then
     pyenv rehash
   fi
 else
-  brew_install_or_upgrade 'python3'
+  brew bundle --file=- <<EOF
+  brew 'python3'
+EOF
 fi
 
 if ! brew_is_installed "pyenv-virtualenvwrapper"; then
@@ -262,36 +208,12 @@ bundle config --global jobs $((number_of_cores - 1))
 
 fancy_echo '...Finished Ruby installation checks.'
 
-brew_tap 'caskroom/cask'
-
-brew_install_or_upgrade 'brew-cask'
-
-brew_tap 'caskroom/versions'
-
-brew_cask_install 'cloud'
-brew_cask_install 'flux'
-brew_cask_install 'github-desktop'
-brew_cask_install 'slack'
-brew_cask_install 'sublime-text3'
-
 if [ -f "$HOME/.laptop.local" ]; then
   . "$HOME/.laptop.local"
 fi
 
 append_to_file "$HOME/.rvmrc" 'rvm_auto_reload_flag=2'
 append_to_file "$HOME/.rvm/gemsets/global.gems" 'bundler'
-
-if brew_is_installed 'cloudfoundry-cli'; then
-  brew uninstall --force cloudfoundry-cli
-fi
-brew_tap 'cloudfoundry/homebrew-tap'
-
-if brew_install_or_upgrade 'cf-cli'; then
-  echo "Successfully installed cf-cli"
-else
-  fancy_echo "cf-cli failed to install. If you see a SHA1 mismatch error above, please report it here:"
-  echo "https://github.com/cloudfoundry/homebrew-tap/issues"
-fi
 
 if app_is_installed 'GitHub'; then
   fancy_echo "It looks like you've already configured your GitHub SSH keys."


### PR DESCRIPTION
**Why**:
Homebrew-bundle does what the custom functions used to do. It also allows us to
use a Brewfile, which makes it easier to see in one place what gets installed,
and makes it easier to customize that list.

As part of moving to a Brewfile, I also removed the directives to restart
Redis, Postgres, and MySQL. Given that the script installs Homebrew services,
managing services manually is very easy, and the user can choose when to start
them.