### PR TITLE
Allow git secrets commands to be run many times

### DIFF
--- a/mac
+++ b/mac
@@ -225,11 +225,11 @@ fi
 git secrets --install -f "$HOME/.git-secrets"
 git config --global init.templatedir "$HOME/.git-secrets"
 git config --global core.hooksPath "$HOME/.git-secrets/hooks"
-git secrets --register-aws --global
+git secrets --register-aws --global || true
 find secret-patterns -type f -name '*.txt' -exec awk 'NF FNR==1{print ""}1' {} + > "$HOME/.git-secrets/patterns"
-git secrets --add-provider --global -- cat "$HOME/.git-secrets/patterns"
-git secrets --add --allowed --global 'github.com.*/[A-Za-z0-9]{40}'
-git secrets --add --allowed --global 'sha.*[A-Za-z0-9]{40}'
-git secrets --add --allowed --global 'secure:.*'
+git secrets --add-provider --global -- cat "$HOME/.git-secrets/patterns" || true
+git secrets --add --allowed --global 'github.com.*/[A-Za-z0-9]{40}' || true
+git secrets --add --allowed --global 'sha.*[A-Za-z0-9]{40}' || true
+git secrets --add --allowed --global 'secure:.*' || true
 
 fancy_echo 'All done!'


### PR DESCRIPTION
**Why**: If a git secrets config is already present, running a `git secrets` command will exit with status 1, preventing the laptop script from executing the rest of the script.

**How**: Add `|| true` to the end of all `git secrets` commands (except the first one that installs git secrets). See: https://github.com/awslabs/git-secrets/issues/24