### PR TITLE
Temporarily disable git-secrets

### DIFF
--- a/mac
+++ b/mac
@@ -222,14 +222,14 @@ elif [ ! -f "$HOME/.ssh/github_rsa.pub" ]; then
   open ~/Applications/GitHub\ Desktop.app
 fi
 
-git secrets --install -f "$HOME/.git-secrets"
-git config --global init.templatedir "$HOME/.git-secrets"
-git config --global core.hooksPath "$HOME/.git-secrets/hooks"
-git secrets --register-aws --global || true
-find secret-patterns -type f -name '*.txt' -exec awk 'NF FNR==1{print ""}1' {} + > "$HOME/.git-secrets/patterns"
-git secrets --add-provider --global -- cat "$HOME/.git-secrets/patterns" || true
-git secrets --add --allowed --global 'github.com.*/[A-Za-z0-9]{40}' || true
-git secrets --add --allowed --global 'sha.*[A-Za-z0-9]{40}' || true
-git secrets --add --allowed --global 'secure:.*' || true
+# git secrets --install -f "$HOME/.git-secrets"
+# git config --global init.templatedir "$HOME/.git-secrets"
+# git config --global core.hooksPath "$HOME/.git-secrets/hooks"
+# git secrets --register-aws --global || true
+# find secret-patterns -type f -name '*.txt' -exec awk 'NF FNR==1{print ""}1' {} + > "$HOME/.git-secrets/patterns"
+# git secrets --add-provider --global -- cat "$HOME/.git-secrets/patterns" || true
+# git secrets --add --allowed --global 'github.com.*/[A-Za-z0-9]{40}' || true
+# git secrets --add --allowed --global 'sha.*[A-Za-z0-9]{40}' || true
+# git secrets --add --allowed --global 'secure:.*' || true
 
 fancy_echo 'All done!'


### PR DESCRIPTION
**Why**: It’s not ready for prime time yet.

- We need to make sure the regexes don’t flag common false positives
- We need to figure out the best way to incorporate configuration files while making the sure the user has those files locally. Currently, the script assumes the user has the `secret-patterns` folder, but because they install the script by only downloading the `mac` and `Brewfile` files via curl, they don’t have the folder. We need to determine if it makes sense to have the user download every file the script needs, or if they should clone the repo instead.