### PR TITLE
Install nvm instead of n

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ What it sets up
 * [Homebrew Services] so you can easily stop, start, and restart services
 * [hub] for interacting with the GitHub API
 * [MySQL] for storing relational data
-* [n] for managing Node.js versions if you do not have [Node.js] already installed (Includes latest [Node.js] and [NPM], for running apps and installing JavaScript packages)
+* [nvm] for managing Node.js versions if you do not have [Node.js] already installed (Includes latest [Node.js] and [NPM], for running apps and installing JavaScript packages)
 * [PhantomJS] for headless website testing
 * [Postgres] for storing relational data
 * [pyenv] for managing Python versions if you do not have [Python] already installed (includes the latest 3.x [Python])

--- a/mac
+++ b/mac
@@ -116,7 +116,7 @@ fancy_echo 'Checking on Node.js installation...'
 
 if ! brew_is_installed "node"; then
   if command -v n > /dev/null; then
-    fancy_echo "We recommend using `nvm` and not `n`."
+    fancy_echo "We recommend using \`nvm\` and not \`n\`."
     fancy_echo "See https://pages.18f.gov/frontend/#install-npm"
   elif ! command -v nvm > /dev/null; then
     fancy_echo 'Installing nvm and lts Node.js and npm...'

--- a/mac
+++ b/mac
@@ -115,13 +115,16 @@ append_to_file "$HOME/.zshrc" 'eval "$(hub alias -s)"'
 fancy_echo 'Checking on Node.js installation...'
 
 if ! brew_is_installed "node"; then
-  if ! command -v nvm > /dev/null; then
+  if command -v n > /dev/null; then
+    fancy_echo "We recommend using `nvm` and not `n`."
+    fancy_echo "See https://pages.18f.gov/frontend/#install-npm"
+  elif ! command -v nvm > /dev/null; then
     fancy_echo 'Installing nvm and lts Node.js and npm...'
     touch ~/.bash_profile
     curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.31.7/install.sh | bash
     nvm install --lts 
   else
-    fancy_echo 'nvm detected.  Skipping...'
+    fancy_echo 'version manager detected.  Skipping...'
   fi
 else
   brew bundle --file=- <<EOF

--- a/mac
+++ b/mac
@@ -116,13 +116,10 @@ fancy_echo 'Checking on Node.js installation...'
 
 if ! brew_is_installed "node"; then
   if ! command -v nvm > /dev/null; then
-    if ! command -v n > /dev/null; then
-      fancy_echo 'Installing n and latest Node.js and NPM...'
-      curl -L http://git.io/n-install | bash -s -- -y latest
-    else
-      fancy_echo 'Updating n...'
-      n-update -y
-    fi
+    fancy_echo 'Installing nvm and lts Node.js and npm...'
+    touch ~/.bash_profile
+    curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.31.7/install.sh | bash
+    nvm install --lts 
   else
     fancy_echo 'nvm detected.  Skipping...'
   fi


### PR DESCRIPTION
As the front end guild standardized it here: https://pages.18f.gov/frontend/#install-npm. It was standardized over `n` because it doesn't require sudo to install global packages.