### PR TITLE
Installs latest Ruby when RVM is already present

### DIFF
--- a/mac
+++ b/mac
@@ -203,6 +203,8 @@ if ! command -v rbenv >/dev/null; then
     else
       fancy_echo "Already using the latest version of RVM. Skipping..."
     fi
+    fancy_echo "Installing the latest stable Ruby..."
+    rvm install ruby --latest
   fi
 fi
 


### PR DESCRIPTION
When the installer detects RVM already on the machine, it will check the
current version of RVM, upgrade if necessary and now also install the latest
stable version of Ruby.
