### PR TITLE
General cleanup of git seekrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ More [detailed instructions with a video][video] are available in the Wiki.
 [Spotlight]: https://support.apple.com/en-us/HT204014
 [video]: https://github.com/18F/laptop/wiki/Detailed-installation-instructions-with-video
 
+### Want to install just git-seekret?
+```sh
+curl -s https://raw.githubusercontent.com/18F/laptop/master/seekrets-install | sh -
+```
+
 Debugging
 ---------
 
@@ -68,7 +73,7 @@ What it sets up
 * [CloudApp] for sharing screenshots and making an animated GIF from a video
 * [Cloud Foundry CLI] for command line access to 18F's Cloud Foundry-based application platform
 * [Flux] for adjusting your Mac's display color so you can sleep better
-* [git secrets] for preventing you from committing passwords and other sensitive information to a git repository
+* [git-seekret] for preventing you from committing passwords and other sensitive information to a git repository
 * [GitHub Desktop] for setting up your SSH keys automatically
 * [Homebrew] for managing operating system libraries
 * [Homebrew Cask] for quickly installing Mac apps from the command line
@@ -92,7 +97,7 @@ What it sets up
 [CloudApp]: http://getcloudapp.com/
 [Cloud Foundry CLI]: https://github.com/cloudfoundry/cli
 [Flux]: https://justgetflux.com/
-[git secrets]: https://github.com/awslabs/git-secrets
+[git-seekret]: https://github.com/18F/git-seekret
 [GitHub Desktop]: https://desktop.github.com/
 [Homebrew]: http://brew.sh/
 [Homebrew Cask]: http://caskroom.io/

--- a/mac
+++ b/mac
@@ -234,14 +234,7 @@ elif [ ! -f "$HOME/.ssh/github_rsa.pub" ]; then
   open ~/Applications/GitHub\ Desktop.app
 fi
 
-# shellcheck disable=SC2039
-CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-WORK_DIR=$( mktemp -d -t "$( basename "${CURRENT_DIR}" )" )
 # TODO: Change to master for merge
-curl -o "${WORK_DIR}/seekrets-install" https://raw.githubusercontent.com/18F/laptop/seekret/seekrets-install > /dev/null 2>&1
-chmod +x "${WORK_DIR}/seekrets-install"
-"${WORK_DIR}/seekrets-install"
-rm -rf "${WORK_DIR}"
-
+curl -s https://raw.githubusercontent.com/18F/laptop/seekret/seekrets-install | sh -
 
 fancy_echo 'All done!'

--- a/seekrets-install
+++ b/seekrets-install
@@ -39,12 +39,12 @@ set -e
 
 if toolversion git '>=' 2.9.1; then
   fancy_echo "Installing Seekret"
-  mkdir -p "${HOME}/.temp_workspace"
-  pushd "${HOME}/.temp_workspace"
-  git init
+  WORK_DIR=$( mktemp -d -t "$( basename "${CURRENT_DIR}" )" )
+  pushd "${WORK_DIR}" > /dev/null 2>&1
+  git init > /dev/null 2>&1
   LATEST_RELEASE_URL=$(curl -s https://api.github.com/repos/18F/git-seekret/releases | grep browser_download_url | grep 'osx' | head -n 1 | cut -d '"' -f 4)
   AWS_URL=$(curl -s "$LATEST_RELEASE_URL" | cut -d '"' -f2 | sed -e "s/amp\;//g")
-  (curl "$AWS_URL" -o /usr/local/bin/git-seekret \
+  (curl "$AWS_URL" -o /usr/local/bin/git-seekret > /dev/null 2>&1 \
     && chmod u+x /usr/local/bin/git-seekret)
 
   fancy_echo "Downloading Seekret rules"
@@ -55,9 +55,10 @@ if toolversion git '>=' 2.9.1; then
   SEEKRET_RULES="${SEEKRET_RULES:=$SEEKRET_DEFAULT_RULES}"
   for rule in ${SEEKRET_RULES}
   do
-      printf "%s: " "$rule"
+      printf "\t%s: " "$rule"
       (cd "${SEEKRET_RULES_PATH}" \
-	  && curl -# -o "${rule}" "${SEEKRET_RULES_URL}/${rule}")
+	  && curl -# -o "${rule}" "${SEEKRET_RULES_URL}/${rule}" > /dev/null 2>&1)
+      printf "done\n"
   done
   fancy_echo "Configuring Seekret"
   mkdir -p "${HOME}/.git-support/hooks"
@@ -67,8 +68,8 @@ if toolversion git '>=' 2.9.1; then
   git seekret --global rules --enable-all
   git seekret --global hook --enable-all
 
-  popd "${HOME}/.temp_workspace"
-  rm -rf "${HOME}/.temp_workspace"
+  popd "${WORK_DIR}" > /dev/null 2>&1
+  rm -rf "${WORK_DIR}"
   fancy_echo "Finished installing Seekret"
 else
   echo


### PR DESCRIPTION
Small cleanup of some final issues:
- use `mktemp` for our work dir, which prevents race conditions
- Actually update the README as appropriate
- clean up how `mac` calls the `seekrets-install` in same way user would from README
- Hide various output that is just noise by redirecting to `/dev/null`

/cc @alain-hoang 