### PR TITLE
Insure that tests are using the local repo

### DIFF
--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -6,6 +6,7 @@ LOCAL_SEEKRETS="$(dirname $BATS_TEST_DIRNAME)/seekret-rules"
 setupGitRepo() {
     git init "${REPO_PATH}"
     git config --local gitseekret.rulespath "$LOCAL_SEEKRETS"
+    git config --global gitseekret.rulespath "$LOCAL_SEEKRETS"
     (cd "${REPO_PATH}" && git-seekret rules --enable-all)
 }
 

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -1,9 +1,11 @@
 #!/usr/bin/env bats
 
 REPO_PATH=$(mktemp -d "${BATS_TMPDIR}/gittest.XXXXXX")
+LOCAL_SEEKRETS="$(dirname $BATS_TEST_DIRNAME)/seekret-rules"
 
 setupGitRepo() {
     git init "${REPO_PATH}"
+    git config --local gitseekret.rulespath "$LOCAL_SEEKRETS"
     (cd "${REPO_PATH}" && git-seekret rules --enable-all)
 }
 


### PR DESCRIPTION
When we're testing things, we shouldn't rely on the installation but rather we should rely on what we're committing locally.