### PR TITLE
Use files in `seekret-rules` to determine defaults

### DIFF
--- a/seekrets-install
+++ b/seekrets-install
@@ -2,10 +2,7 @@
 
 # Add new baseline rules here
 #rsa-private.rule
-SEEKRET_DEFAULT_RULES="
-aws.rule
-newrelic.rule
-mandrill.rule"
+SEEKRET_DEFAULT_RULES=$( ls ./seekret-rules )
 
 fancy_echo() {
   # shellcheck disable=SC2039

--- a/seekrets-install
+++ b/seekrets-install
@@ -2,7 +2,15 @@
 
 # Add new baseline rules here
 #rsa-private.rule
-SEEKRET_DEFAULT_RULES=$( ls ./seekret-rules )
+SEEKRET_DEFAULT_RULES="
+aws.rule
+newrelic.rule
+mandrill.rule"
+
+if [ -d ./seekret-rules ]
+then
+  SEEKRET_DEFAULT_RULES=$( ls ./seekret-rules )
+fi
 
 fancy_echo() {
   # shellcheck disable=SC2039


### PR DESCRIPTION
Secret rules should be coming from within the repository itself and shouldn't be hard-coded. This will allow for a shorter feedback loop for local development and came up during the Git Seekret documentation #116

cc: @alain-hoang