### PR TITLE
Add change shell instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,35 @@ To start all services at once:
 brew services start --all
 ```
 
+How to switch your shell back to bash from zsh (or vice versa)
+--------------------------------------------------------------
+1. Find out which shell you're currently running: `echo $SHELL`
+2. Find out the location of the shell you want to switch to. For example, if
+   you want to switch to `bash`, run `which bash`.
+3. Verify if the shell location is included in `/etc/shells`.
+   Run `cat /etc/shells` to see the contents of the file.
+4. If the location of the shell is included, run
+   `chsh -s [the location of the shell]`.
+   For example, if `which bash` returned `/bin/bash`, you would run
+  `chsh -s /bin/bash`.
+
+   If the location of the shell is not in `/etc/shells`, add it, then run the
+   `chsh` command.
+   If you have Sublime Text, you can open the file by running
+   `subl /etc/shells`.
+5. Quit and restart Terminal (or iTerm2), or open a new tab for the new shell
+   to take effect.
+
+Whether you're using bash or zsh, we recommend installing the latest versions
+with Homebrew because the versions that came with your Mac are really old.
+```
+brew install bash
+```
+or
+```
+brew install zsh
+```
+
 Credits
 -------
 

--- a/mac
+++ b/mac
@@ -71,6 +71,8 @@ case "$SHELL" in
       echo "Both work fine for development, and ${bold}zsh${normal} has some extra "
       echo "features for customization and tab completion."
       echo "If you aren't sure or don't care, we recommend ${bold}zsh${normal}."
+      echo "Note that you can always switch back to ${bold}bash${normal} if you change your mind."
+      echo "Please see the README for instructions."
       echo -n "Press ${bold}y${normal} to switch to zsh, ${bold}n${normal} to keep bash: "
       read -r -n 1 response
       if [ "$response" = "y" ]; then
@@ -79,13 +81,6 @@ case "$SHELL" in
         echo "=== Press control-c to cancel ==="
         create_zshrc_and_set_it_as_shell_file
         chsh -s "$(which zsh)"
-        echo "Note that you can always switch back to ${bold}bash${normal} if you change your mind."
-        echo "To do that, run ${bold}chsh -s $(which bash)${normal}"
-        echo "Then quit and restart your Terminal app for the changes to take effect."
-        echo "Then, we recommend installing the latest version of ${bold}bash${normal} with Homebrew,"
-        echo "because the one that came with your Mac is really old."
-        echo "Run ${bold}brew install bash${normal} to install the latest version."
-        echo "Then quit and restart your Terminal app for the changes to take effect."
       else
         fancy_echo "Shell will not be changed."
       fi


### PR DESCRIPTION
**Why**: To provide an easy way to refer back to the instructions
without having to run the script.

Also, moved the note about being able to switch back to before the shell
is changed.