### PR TITLE
Force fetch latest Homebrew

### DIFF
--- a/mac
+++ b/mac
@@ -142,8 +142,8 @@ if brew_is_installed 'brew-cask'; then
   brew untap caskroom/versions
 fi
 
-fancy_echo "Updating Homebrew formulas ..."
-brew update
+fancy_echo "Updating Homebrew..."
+cd "$(brew --repo)" && git fetch && git reset --hard origin/master && brew update
 
 fancy_echo "Verifying the Homebrew installation..."
 if brew doctor; then


### PR DESCRIPTION
**Why**: Sometimes, `brew update` doesn’t actually get the latest commit from the repo due to a known issue with Homebrew. We want to make sure we have the latest commit from Homebrew/brew because it fixes a nasty bug where existing Mac apps that the script attempts to install are removed. See: https://github.com/Homebrew/brew/issues/1785