### PR TITLE
Don’t use OS X image for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,17 @@
-os:
-  - osx
+dist: trusty
+sudo: true
 
 language: sh
 
 before_script:
-  - brew install shellcheck
-  - git clone https://github.com/sstephenson/bats.git /tmp/bats && pushd /tmp/bats && ./install.sh /usr/local && popd
+  - sudo apt-get update; sudo apt-get install athena-jot
+  - wget "http://ftp.debian.org/debian/pool/main/s/shellcheck/shellcheck_0.4.4-4_amd64.deb"
+  - sudo dpkg -i "shellcheck_0.4.4-4_amd64.deb"
+  - export PATH="/usr/local/bin:$PATH"
+  - git clone https://github.com/sstephenson/bats.git /tmp/bats && pushd /tmp/bats && sudo ./install.sh /usr/local && popd
+  - cat seekrets-install | bash -
 
 script:
   - shellcheck mac
   - shellcheck seekrets-install
-  - bash mac
   - bats test/seekrets.bats

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,15 @@
+machine:
+  pre:
+    - sudo apt-get update; sudo apt-get install athena-jot
+    - wget "http://ftp.debian.org/debian/pool/main/s/shellcheck/shellcheck_0.4.4-4_amd64.deb"
+    - sudo dpkg -i "shellcheck_0.4.4-4_amd64.deb"
+    - export PATH="/usr/local/bin:$PATH"
+    - git clone https://github.com/sstephenson/bats.git /tmp/bats && pushd /tmp/bats && sudo ./install.sh /usr/local && popd
+
+test:
+  override:
+    - cat seekrets-install | bash -
+  post:
+    - shellcheck mac
+    - shellcheck seekrets-install
+    - bats test/seekrets.bats

--- a/seekrets-install
+++ b/seekrets-install
@@ -67,7 +67,7 @@ if toolversion git '>=' 2.9.1; then
   AWS_URL=$(curl -s "https://github.com${LATEST_RELEASE_URL}" | cut -d '"' -f2 | sed -e "s/amp\;//g")
   BIN_LOCATION="/usr/local/bin"
   SUDO_REQUIRED=true
-  if [[ ":$PATH:" == *":$HOME/bin:"* ]]; then
+  if [[ -d "$HOME/bin" && ":$PATH:" == *":$HOME/bin:"* ]]; then
     BIN_LOCATION="$HOME/bin"
     SUDO_REQUIRED=false
   fi

--- a/test/seekrets.bats
+++ b/test/seekrets.bats
@@ -47,73 +47,68 @@ load test_helper
 
 @test "git-seekrets does find aws secrets in test repo" {
     run addFileWithAwsSecrets
-    [ $status -gt 0 ]
+    [ $(echo "$output" | grep -c 'Found Secrets: 2') -eq 1 ]
 }
 
 @test "git-seekrets does find aws accounts in test repo" {
     run addFileWithAwsAccounts
-    [ $status -gt 0 ]
+    [ $(echo "$output" | grep -c 'Found Secrets: 1') -eq 1 ]
 }
 
 @test "git-seekrets does find aws access keys in test repo" {
     run addFileWithAwsAccessKey
-    [ $status -gt 0 ]
+    [ $(echo "$output" | grep -c 'Found Secrets: 2') -eq 1 ]
 }
 
 @test "git-seekrets does not find newrelic keys as aws keys in test repo" {
     enableOnlyRuleFile "aws"
     run addFileWithNewrelicSecrets
-    [ $status -eq 0 ]
     [ $(echo "$output" | grep -c 'Found Secrets: 0') -eq 1 ]
 }
 
 @test "git-seekrets does find newrelic secrets in test repo" {
-    run addFileWithNewRelicSecrets
-    [ $status -gt 0 ]
+    run addFileWithNewrelicSecrets
+    [ $(echo "$output" | grep -c 'Found Secrets: 1') -eq 1 ]
 }
 
 @test "git-seekrets does not find newrelic false positives in test repo" {
     run addFileWithFalseNewrelicSecrets
-    [ $status -eq 0 ]
     [ $(echo "$output" | grep -c 'Found Secrets: 0') -eq 1 ]
 }
 
 @test "git-seekrets only matches newrelic secrets in test repo" {
     run addFileWithSomeNewrelicSecrets
-    [ $status -gt 0 ]
     [ $(echo "$output" | grep -c 'Found Secrets: 1') -eq 1 ]
 }
 
 @test "git-seekrets does find mandrill keys in test repo" {
     run addFileWithMandrillKey
-    [ $status -gt 0 ]
+    [ $(echo "$output" | grep -c 'Found Secrets: 1') -eq 1 ]
 }
 
 @test "git-seekrets does not find mandrill key false positives in test repo" {
     run addFileWithFalseMandrillKey
-    [ $status -eq 0 ]
     [ $(echo "$output" | grep -c 'Found Secrets: 0') -eq 1 ]
 }
 
 @test "git-seekrets does find mandrill passwords in test repo" {
     run addFileWithMandrillPassword
-    [ $status -gt 0 ]
+    [ $(echo "$output" | grep -c 'Found Secrets: 2') -eq 1 ]
 }
 
 @test "git-seekrets does not find mandrill password false positives in test repo" {
     run addFileWithFalseMandrillPassword
-    [ $status -eq 0 ]
     [ $(echo "$output" | grep -c 'Found Secrets: 0') -eq 1 ]
 }
 
 @test "git-seekrets does find mandrill usernames in test repo" {
     run addFileWithMandrillUsername
-    [ $status -gt 0 ]
+    [ $(echo "$output" | grep -c 'Found Secrets: 1') -eq 1 ]
 }
 
 @test "git-seekrets does not find secrets in test repo" {
     run addFileWithNoSecrets
-    [ $status -eq 0 ]
+    [ $(echo "$output" | grep -c 'Found Secrets: 0') -eq 1 ]
 }
 
 @test "git-seekrets can disable all rulesets" {

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -6,7 +6,10 @@ setupGitRepo() {
     git init "${REPO_PATH}"
     git config --local gitseekret.rulespath "$LOCAL_SEEKRETS"
     git config --global gitseekret.rulespath "$LOCAL_SEEKRETS"
-    (cd "${REPO_PATH}" && git-seekret rules --enable-all)
+    (cd "${REPO_PATH}" && \
+        git config user.email "example@example.com" && \
+        git config user.name "Example User" && \
+        git-seekret rules --enable-all)
 }
 
 cleanGitRepo() {


### PR DESCRIPTION
**Why**:
- It’s super slow
- It’s not a clean OS X image. It comes with a bunch of stuff like XCode, Homebrew, RVM, and other settings we might not want, or things we’re not aware of that can interfere with the script.
- None of the bugs we’ve found have been the result of the script failing on Travis.
- It’s more reliable to test changes manually or by having many people use the script and report issues. I also have a spare laptop where I can erase the hard drive and install macOS from scratch.