### PR TITLE
Specify Brewfile path

### DIFF
--- a/mac
+++ b/mac
@@ -161,7 +161,13 @@ if brew_is_installed 'cloudfoundry-cli'; then
 fi
 
 fancy_echo "Installing formulas and casks from the Brewfile ..."
-brew bundle
+if brew bundle --file="$HOME/Brewfile"; then
+  fancy_echo "All formulas and casks were installed successfully."
+else
+  fancy_echo "Some formulas or casks failed to install."
+  echo "This is usually due to one of the Mac apps being already installed,"
+  echo "in which case, you can ignore these errors."
+fi
 
 # shellcheck disable=SC2016
 append_to_file "$shell_file" 'eval "$(hub alias -s)"'


### PR DESCRIPTION
**Why**: Due to the new way of installing the script via curl and piping to `sh`, it doesn’t see the `Brewfile`, so we must explicitly specify its path.