### PR TITLE
Add seekret rule for Slack API tokens

### DIFF
--- a/seekret-rules/slack.rule
+++ b/seekret-rules/slack.rule
@@ -1,0 +1,2 @@
+api_token:
+  match: (\"|')?(SLACK|Slack|slack)?_?(API|Api|api)?_?(TOKEN|Token|token)?_?(\"|')?\s*(:|=>|=)?\s*(\"|')?xox[a-z]-\d{11}-\d{12}-\d{12}-[a-z\d]{32}(\"|')?

--- a/seekrets-install
+++ b/seekrets-install
@@ -7,7 +7,8 @@ SCRIPTPATH=$( cd "$(dirname "$0")" ; pwd -P )
 SEEKRET_DEFAULT_RULES="
 aws.rule
 newrelic.rule
-mandrill.rule"
+mandrill.rule
+slack.rule"
 
 if [ -d "${SCRIPTPATH}/seekret-rules" ]; then
   SEEKRET_DEFAULT_RULES=$( ls "${SCRIPTPATH}/seekret-rules" )

--- a/test/seekrets.bats
+++ b/test/seekrets.bats
@@ -106,6 +106,11 @@ load test_helper
     [ $(echo "$output" | grep -c 'Found Secrets: 1') -eq 1 ]
 }
 
+@test "git-seekrets does find slack api token in test repo" {
+    run addFileWithSlackAPIToken
+    [ $(echo "$output" | grep -c 'Found Secrets: 1') -eq 1 ]
+}
+
 @test "git-seekrets does not find secrets in test repo" {
     run addFileWithNoSecrets
     [ $(echo "$output" | grep -c 'Found Secrets: 0') -eq 1 ]

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -214,6 +214,16 @@ addFileWithMandrillUsername() {
     (cd ${REPO_PATH} && git commit -m 'test commit')
 }
 
+addFileWithSlackAPIToken() {
+    local secrets_file="${REPO_PATH}/slacktokenfile.md"
+
+    touch "${secrets_file}"
+    echo "SHHHH... Secrets in this file" >> "${secrets_file}"
+    echo "slack_api_token=xoxo-11111111111-222222222222-333333333333-0123456789abcdef0123456789abcdef" >> "${secrets_file}"
+    (cd "${REPO_PATH}" && git add "${secrets_file}")
+    (cd ${REPO_PATH} && git commit -m 'test commit')
+}
+
 setup() {
     setupGitRepo
 }


### PR DESCRIPTION
Slack API tokens, conveniently, always start with `xox*`, so identifying them is pretty easy.  They then have 11 digits, 12 digits, 12 digits, and 32 alphanumeric characters (they look like hex characters but I'm not sure, so I tested for a-z, 0-9).