### PR TITLE
Fix installation command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ and once it appears, press `return` to launch it.
 In your Terminal window, copy and paste the command below, then press `return`.
 
 ```sh
-curl -s https://raw.githubusercontent.com/18F/laptop/master/laptop | sh -
+bash <(curl -s https://raw.githubusercontent.com/18F/laptop/master/laptop)
 ```
 The [script](https://github.com/18F/laptop/blob/master/mac) itself is
 available in this repo for you to review if you want to see what it does

--- a/mac
+++ b/mac
@@ -125,7 +125,7 @@ switch_to_latest_ruby() {
   chruby "ruby-$(latest_installed_ruby)"
 }
 
-append_to_file "$shell_file" "alias laptop='curl -s https://raw.githubusercontent.com/18F/laptop/master/laptop | sh -'"
+append_to_file "$shell_file" "alias laptop='bash <(curl -s https://raw.githubusercontent.com/18F/laptop/master/laptop)'"
 
 # shellcheck disable=SC2016
 append_to_file "$shell_file" 'export PATH="$HOME/.bin:$PATH"'


### PR DESCRIPTION
Since the `mac` script involves reading from user input, we can't
pipe the curl command to `sh` or `bash` because we would be asking
bash to read from both a file and STDIN.

The solution is to use redirection of STDIN

See: http://unix.stackexchange.com/a/247221