### PR TITLE
Removed unnecessary git commands

### DIFF
--- a/mac
+++ b/mac
@@ -152,7 +152,7 @@ if tap_is_installed 'caskroom/versions'; then
 fi
 
 fancy_echo "Updating Homebrew..."
-cd "$(brew --repo)" && git fetch && git reset --hard origin/master && brew update
+brew update
 
 fancy_echo "Verifying the Homebrew installation..."
 if brew doctor; then


### PR DESCRIPTION
These commands appear to have been put into resolve a long-fixed homebrew bug. In some cases,  they may break the homebrew git repo link, and in any case they should not be needed.