### PR TITLE
PhantomJS moved to cask tap

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -13,13 +13,12 @@ brew 'mysql'
 
 brew 'redis'
 
-brew 'phantomjs'
-
 brew 'hub'
 
 tap 'cloudfoundry/homebrew-tap'
 brew 'cf-cli'
 
+cask 'phantomjs'
 cask 'cloudapp'
 cask 'flux'
 cask 'github'


### PR DESCRIPTION
It's also been abandoned and archived. Maybe it should actually just be removed?