### PR TITLE
A variety of changes to address longstanding issues

### DIFF
--- a/.laptop.local
+++ b/.laptop.local
@@ -2,6 +2,10 @@
 
 fancy_echo "Running your customizations from ~/.laptop.local ..."
 
+# Install oh-my-zsh, a bunch of configurations for zsh that make it
+# a bunch more useful
+# sh -c "$(curl -fsSL https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh)"
+
 if [ -f "$HOME/Brewfile.local" ]; then
   if brew bundle --file="$HOME/Brewfile.local"; then
     fancy_echo "All items in Brewfile.local were installed successfully."

--- a/Brewfile.local
+++ b/Brewfile.local
@@ -11,3 +11,7 @@ brew 'tmux'
 brew 'reattach-to-user-namespace'
 
 brew 'go'
+
+# Install GNU coreutils and have them mask the macOS versions.  See
+# https://github.com/18F/laptop/issues/36 for more info.
+# brew install coreutils --default-names

--- a/README.md
+++ b/README.md
@@ -64,6 +64,13 @@ curl -s https://raw.githubusercontent.com/18F/laptop/master/seekrets-install | b
 ```
 Note that the script may ask you to enter your password. This is the same password that you use to log in to your computer.
 
+> git-seekret requires git 2.9.1 or higher.  Some versions of Ubuntu ship with an older version.  To update your git before installing git-seekret:
+> 
+> ```
+> sudo add-apt-repository ppa:git-core/ppa
+> sudo apt-get update
+> ```
+
 **git-seekret will install global git hooks into ~/.git-support/hooks.   To restore pre-existing git hooks, it is recommended to save pre-existing hooks into a separate directory and to copy those hooks into ~/.git-support/hooks after git-seekret is installed.**
 
 Development

--- a/seekrets-install
+++ b/seekrets-install
@@ -22,23 +22,44 @@ fancy_echo() {
   printf "\n$fmt\n" "$@"
 }
 
-toolversion() {
+toolminversion() {
     # shellcheck disable=SC2039
-    local prog="$1" operator="$2" value="$3" version
+    local prog="$1" value="$2" version
 
     version=$($prog --version | awk '{print $NF; exit}')
 
     awk -v v1="$version" -v v2="$value" 'BEGIN {
         split(v1, a, /\./); split(v2, b, /\./);
-        if (a[2] == b[2]) {
-          exit (a[3] '"${operator}"' b[3]) ? 0 : 1
+
+        if (a[1] < b[1]) {
+          # major version is lower
+          exit 1;
         }
-        else if (a[1] == b[1]) {
-          exit (a[2] '"${operator}"' b[2]) ? 0 : 1
+        if (a[1] > b[1]) {
+          # major version is higher
+          exit 0;
         }
-        else {
-          exit (a[1] '"${operator}"' b[1]) ? 0 : 1
+
+        # major versions match
+
+        if (a[2] < b[2]) {
+          # minor version is lower
+          exit 2;
         }
+        if (a[2] > b[2]) {
+          # minor version is higher
+          exit 0;
+        }
+
+        # minor versions match
+
+        if(a[3] < b[3]) {
+          #patch version is lower
+          exit 3;
+        }
+
+        # patch version is higher or matches
+        exit 0;
     }'
 }
 
@@ -59,7 +80,7 @@ get_platform() {
 
 set -e
 
-if toolversion git '>=' 2.9.1; then
+if toolminversion git 2.9.1; then
   fancy_echo "Installing Seekret"
   WORK_DIR=$( mktemp -d -t "$( basename "$(pwd)XXXXX" )" )
   pushd "${WORK_DIR}" > /dev/null


### PR DESCRIPTION
- adds `oh-my-zsh` install to `.laptop.local` but comments it out (closes #32)
- adds GNU coreutils to `Brewfile.local` but comments it out (closes #36)
- adds a note in the README about updating git on older versions of Ubuntu before installing git-seekret (closes #136)
- fixes a tool version check bug (closes #141)