### PR TITLE
Fix nvm LTS install

### DIFF
--- a/mac
+++ b/mac
@@ -191,7 +191,7 @@ if ! brew_is_installed "node"; then
     export NVM_DIR="$HOME/.nvm"
     # shellcheck source=/dev/null
     [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-    nvm install node --lts
+    nvm install --lts
   else
     fancy_echo 'version manager detected.  Skipping...'
   fi

--- a/mac
+++ b/mac
@@ -191,7 +191,17 @@ if ! brew_is_installed "node"; then
     export NVM_DIR="$HOME/.nvm"
     # shellcheck source=/dev/null
     [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+
+    # nvm is a bash script itself, some commands of which may fail WITHOUT
+    # causing the whole operation to fail. To accomdate that, disable exit on
+    # any nonzero exit code while nvm runs.
+    set +e
+
     nvm install --lts
+
+    # Turn it back on when nvm is done, since the rest of this script may have
+    # been written assuming this behavior.
+    set -e
   else
     fancy_echo 'version manager detected.  Skipping...'
   fi


### PR DESCRIPTION
The command `nvm install node --lts` installs the latest version of Node.js, not the latest LTS version.  To fix, remove `node`.  This seems to be a change in the behavior of nvm.

Additionally, the `mac` script is configured to exit if any command within it exits with a non-zero code.  However, `nvm` is itself a bash script that has commands that have non-zero exit codes that are NOT exceptional.  That is, a successful `nvm install` may include some commands exiting with non-zero statuses.  To handle that, this PR also disables the "exit if anything is non-zero" when it runs `nvm` and re-enables it afterwards.

Closes #166 