### PR TITLE
When switching to zsh, make sure chsh is valid first

### DIFF
--- a/mac
+++ b/mac
@@ -76,11 +76,22 @@ case "$SHELL" in
       echo -n "Press ${bold}y${normal} to switch to zsh, ${bold}n${normal} to keep bash: "
       read -r -n 1 response
       if [ "$response" = "y" ]; then
-        fancy_echo "=== Getting ready to change your shell to zsh. Please enter your password to continue. ==="
-        echo "=== Note that there won't be visual feedback when you type your password. Type it slowly and press return. ==="
-        echo "=== Press control-c to cancel ==="
         create_zshrc_and_set_it_as_shell_file
-        chsh -s "$(which zsh)"
+        if grep "$(which zsh)" > /dev/null 2>&1 < /etc/shells; then
+          fancy_echo "=== Getting ready to change your shell to zsh. Please enter your password to continue. ==="
+          echo "=== Note that there won't be visual feedback when you type your password. Type it slowly and press return. ==="
+          echo "=== Press control-c to cancel ==="
+          chsh -s "$(which zsh)"
+        else
+          printf "\n\n"
+          echo "Can't switch shells automatically in this case.  The path to zsh isn't in"
+          echo "the list of allowed shells.  To manually switch to zsh, enter the following"
+          echo "two lines into your terminal (in another tab, or when this script is done):"
+          echo ""
+          echo "sudo echo \"\$(which zh)\" >> /etc/shells"
+          echo "chsh -s \"\$(which zs)\""
+          sleep 3
+        fi
       else
         fancy_echo "Shell will not be changed."
       fi


### PR DESCRIPTION
The `chsh` command will fail if the targeted shell is not in `/etc/shells`, which can happen if `zsh` is installed manually rather than using the macOS built-in zsh.  Rather than have it fail, check if the path to the active `zsh` is in `/etc/shells`.  If it is, proceed to `chsh`.  If it is **not**, print out some info about what to do and pause for a moment so the user may have a chance to see it.

So the behavior is this:

1. check if the current shell is zsh
2. if not, ask if they want to switch - do this even if we cannot switch so if they choose no, we don't hassle them with a message about it
3. if they choose to switch, check if the active zsh is in `/etc/shells`
  - if not, give the user instructions for how to switch and pause the script for a few seconds
  - if so, `chsh` to zsh
4. proceed