### PR TITLE
Add Fish shell support

### DIFF
--- a/mac
+++ b/mac
@@ -311,6 +311,14 @@ case "$SHELL" in
     brew 'rbenv'
 EOF
     append_to_file "$shell_file" "status --is-interactive; and source (rbenv init -|psub)"
+    # rbenv currently doesn't have a convenience version to use, e.g., "latest",
+    # so we check for the latest version against Homebrew instead.
+    latest_ruby="$(brew info ruby | egrep -o "\d+\.\d+\.\d+" | head -1)"
+    if ! rbenv versions | ag "$latest_ruby" > /dev/null; then
+      rbenv install "$latest_ruby"
+      rbenv global "$latest_ruby"
+      rbenv rehash
+    fi
     ;;
   *) :
     if command -v rbenv >/dev/null || command -v rvm >/dev/null; then

--- a/mac
+++ b/mac
@@ -44,8 +44,8 @@ append_to_posix_shell_file() {
 
 create_and_set_shell_file() {
   shell_file="$1"
-  if [ ! -f $shell_file ]; then
-    touch $shell_file
+  if [ ! -f "$shell_file" ]; then
+    touch "$shell_file"
   fi
 }
 

--- a/mac
+++ b/mac
@@ -205,6 +205,7 @@ fi
 # shellcheck disable=SC2016
 case "$SHELL" in
   */fish) :
+    mkdir -p "$HOME/.config/fish/functions"
     hub alias fish > "$HOME/.config/fish/functions/git.fish"
     ;;
   *) :
@@ -216,39 +217,37 @@ fancy_echo 'Checking on Node.js installation...'
 
 case "$SHELL" in
   */fish) :
-    fancy_echo "Skipping node installation."
     fancy_echo "We recommend following the steps at https://github.com/FabioAntunes/fish-nvm to install nvm in fish"
     ;;
-  *) :
-    if ! brew_is_installed "node"; then
-      if command -v n > /dev/null; then
-        fancy_echo "We recommend using \`nvm\` and not \`n\`."
-        fancy_echo "See https://pages.18f.gov/frontend/#install-npm"
-      elif ! command -v nvm > /dev/null; then
-        fancy_echo 'Installing nvm and lts Node.js and npm...'
-        curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.0/install.sh | bash
-        export NVM_DIR="$HOME/.nvm"
-        # shellcheck source=/dev/null
-        [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-        # nvm is a bash script itself, some commands of which may fail WITHOUT
-        # causing the whole operation to fail. To accomdate that, disable exit on
-        # any nonzero exit code while nvm runs.
-        set +e
-
-        nvm install --lts
-
-        # Turn it back on when nvm is done, since the rest of this script may have
-        # been written assuming this behavior.
-        set -e
-      else
-        fancy_echo 'version manager detected.  Skipping...'
-      fi
-    else
-      brew bundle --file=- <<EOF
-      brew 'node'
-EOF
-    fi
 esac
+if ! brew_is_installed "node"; then
+  if command -v n > /dev/null; then
+    fancy_echo "We recommend using \`nvm\` and not \`n\`."
+    fancy_echo "See https://pages.18f.gov/frontend/#install-npm"
+  elif ! command -v nvm > /dev/null; then
+    fancy_echo 'Installing nvm and lts Node.js and npm...'
+    curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.0/install.sh | bash
+    export NVM_DIR="$HOME/.nvm"
+    # shellcheck source=/dev/null
+    [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+    # nvm is a bash script itself, some commands of which may fail WITHOUT
+    # causing the whole operation to fail. To accomdate that, disable exit on
+    # any nonzero exit code while nvm runs.
+    set +e
+
+    nvm install --lts
+
+    # Turn it back on when nvm is done, since the rest of this script may have
+    # been written assuming this behavior.
+    set -e
+  else
+    fancy_echo 'version manager detected.  Skipping...'
+  fi
+else
+  brew bundle --file=- <<EOF
+  brew 'node'
+EOF
+fi
 
 fancy_echo '...Finished Node.js installation checks.'
 
@@ -317,7 +316,7 @@ EOF
     if ! rbenv versions | ag "$latest_ruby" > /dev/null; then
       rbenv install "$latest_ruby"
       rbenv global "$latest_ruby"
-      rbenv rehash
+      eval "$(rbenv init - bash)"
     fi
     ;;
   *) :

--- a/mac
+++ b/mac
@@ -24,8 +24,6 @@ append_to_file() {
     else
       file="$HOME/.zshrc"
     fi
-  elif [ "$file" = "$HOME/.bash_profile" ]; then
-    file="$HOME/.bash_profile"
   fi
 
   if ! grep -qs "^$text$" "$file"; then
@@ -33,20 +31,34 @@ append_to_file() {
   fi
 }
 
-create_zshrc_and_set_it_as_shell_file() {
-  if [ ! -f "$HOME/.zshrc" ]; then
-    touch "$HOME/.zshrc"
-  fi
+append_to_posix_shell_file() {
+  case "$SHELL" in
+    */fish) :
+      fancy_echo "Not appending %s to config.fish" "$1"
+      ;;
+    *)
+      append_to_file "$shell_file" "$1"
+      ;;
+  esac
+}
 
-  shell_file="$HOME/.zshrc"
+create_and_set_shell_file() {
+  shell_file="$1"
+  if [ ! -f $shell_file ]; then
+    touch $shell_file
+  fi
+}
+
+create_zshrc_and_set_it_as_shell_file() {
+  create_and_set_shell_file "$HOME/.zshrc"
+}
+
+create_fishconfig_and_set_it_as_shell_file() {
+  create_and_set_shell_file "$HOME/.config/fish/config.fish"
 }
 
 create_bash_profile_and_set_it_as_shell_file() {
-  if [ ! -f "$HOME/.bash_profile" ]; then
-    touch "$HOME/.bash_profile"
-  fi
-
-  shell_file="$HOME/.bash_profile"
+  create_and_set_shell_file "$HOME/.bash_profile"
 }
 
 # shellcheck disable=SC2154
@@ -59,6 +71,9 @@ if [ ! -d "$HOME/.bin/" ]; then
 fi
 
 case "$SHELL" in
+  */fish) :
+    create_fishconfig_and_set_it_as_shell_file
+    ;;
   */zsh) :
     create_zshrc_and_set_it_as_shell_file
     ;;
@@ -139,7 +154,7 @@ switch_to_latest_ruby() {
 append_to_file "$shell_file" "alias laptop='bash <(curl -s https://raw.githubusercontent.com/18F/laptop/master/laptop)'"
 
 # shellcheck disable=SC2016
-append_to_file "$shell_file" 'export PATH="$HOME/.bin:$PATH"'
+append_to_posix_shell_file 'export PATH="$HOME/.bin:$PATH"'
 
 if ! command -v brew >/dev/null; then
   fancy_echo "Installing Homebrew ..."
@@ -147,7 +162,7 @@ if ! command -v brew >/dev/null; then
       'https://raw.githubusercontent.com/Homebrew/install/master/install' | ruby
 
     # shellcheck disable=SC2016
-    append_to_file "$shell_file" 'export PATH="/usr/local/bin:$PATH"'
+    append_to_posix_shell_file 'export PATH="/usr/local/bin:$PATH"'
 else
   fancy_echo "Homebrew already installed. Skipping ..."
 fi
@@ -188,42 +203,54 @@ else
 fi
 
 # shellcheck disable=SC2016
-append_to_file "$shell_file" 'eval "$(hub alias -s)"'
+case "$SHELL" in
+  */fish) :
+    hub alias fish > "$HOME/.config/fish/functions/git.fish"
+    ;;
+  *) :
+    append_to_posix_shell_file 'eval "$(hub alias -s)"'
+    ;;
+esac
 
 fancy_echo 'Checking on Node.js installation...'
 
-if ! brew_is_installed "node"; then
-  if command -v n > /dev/null; then
-    fancy_echo "We recommend using \`nvm\` and not \`n\`."
-    fancy_echo "See https://pages.18f.gov/frontend/#install-npm"
-  elif ! command -v nvm > /dev/null; then
-    fancy_echo 'Installing nvm and lts Node.js and npm...'
-    curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.0/install.sh | bash
-    export NVM_DIR="$HOME/.nvm"
-    # shellcheck source=/dev/null
-    [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+case "$SHELL" in
+  */fish) :
+    fancy_echo "Skipping node installation."
+    fancy_echo "We recommend following the steps at https://github.com/FabioAntunes/fish-nvm to install nvm in fish"
+    ;;
+  *) :
+    if ! brew_is_installed "node"; then
+      if command -v n > /dev/null; then
+        fancy_echo "We recommend using \`nvm\` and not \`n\`."
+        fancy_echo "See https://pages.18f.gov/frontend/#install-npm"
+      elif ! command -v nvm > /dev/null; then
+        fancy_echo 'Installing nvm and lts Node.js and npm...'
+        curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.0/install.sh | bash
+        export NVM_DIR="$HOME/.nvm"
+        # shellcheck source=/dev/null
+        [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+        # nvm is a bash script itself, some commands of which may fail WITHOUT
+        # causing the whole operation to fail. To accomdate that, disable exit on
+        # any nonzero exit code while nvm runs.
+        set +e
 
-    # nvm is a bash script itself, some commands of which may fail WITHOUT
-    # causing the whole operation to fail. To accomdate that, disable exit on
-    # any nonzero exit code while nvm runs.
-    set +e
+        nvm install --lts
 
-    nvm install --lts
-
-    # Turn it back on when nvm is done, since the rest of this script may have
-    # been written assuming this behavior.
-    set -e
-  else
-    fancy_echo 'version manager detected.  Skipping...'
-  fi
-else
-  brew bundle --file=- <<EOF
-  brew 'node'
+        # Turn it back on when nvm is done, since the rest of this script may have
+        # been written assuming this behavior.
+        set -e
+      else
+        fancy_echo 'version manager detected.  Skipping...'
+      fi
+    else
+      brew bundle --file=- <<EOF
+      brew 'node'
 EOF
-fi
+    fi
+esac
 
 fancy_echo '...Finished Node.js installation checks.'
-
 
 fancy_echo 'Checking on Python installation...'
 
@@ -233,10 +260,17 @@ if ! brew_is_installed "python3"; then
   brew 'pyenv-virtualenv'
   brew 'pyenv-virtualenvwrapper'
 EOF
-  # shellcheck disable=SC2016
-  append_to_file "$shell_file" 'if which pyenv > /dev/null; then eval "$(pyenv init -)"; fi'
-  # shellcheck disable=SC2016
-  append_to_file "$shell_file" 'if which pyenv-virtualenv-init > /dev/null; then eval "$(pyenv virtualenv-init -)"; fi'
+  case "$SHELL" in
+    */fish) :
+      append_to_file "$shell_file" "status --is-interactive; and source (pyenv init -|psub)"
+      append_to_file "$shell_file" "status --is-interactive; and source (pyenv virtualenv-init -|psub)"
+      ;;
+    *) :
+      # shellcheck disable=SC2016
+      append_to_posix_shell_file 'if which pyenv > /dev/null; then eval "$(pyenv init -)"; fi'
+      # shellcheck disable=SC2016
+      append_to_posix_shell_file 'if which pyenv-virtualenv-init > /dev/null; then eval "$(pyenv virtualenv-init -)"; fi'
+  esac
 
   # pyenv currently doesn't have a convenience version to use, e.g., "latest",
   # so we check for the latest version against Homebrew instead.
@@ -257,9 +291,9 @@ if ! brew_is_installed "pyenv-virtualenvwrapper"; then
   if ! pip3 list | ag "virtualenvwrapper" > /dev/null; then
     fancy_echo 'Installing virtualenvwrapper...'
     pip3 install virtualenvwrapper
-    append_to_file "$shell_file" 'export VIRTUALENVWRAPPER_PYTHON=/usr/local/bin/python3'
-    append_to_file "$shell_file" 'export VIRTUALENVWRAPPER_VIRTUALENV=/usr/local/bin/virtualenv'
-    append_to_file "$shell_file" 'source /usr/local/bin/virtualenvwrapper.sh'
+    append_to_posix_shell_file 'export VIRTUALENVWRAPPER_PYTHON=/usr/local/bin/python3'
+    append_to_posix_shell_file 'export VIRTUALENVWRAPPER_VIRTUALENV=/usr/local/bin/virtualenv'
+    append_to_posix_shell_file 'source /usr/local/bin/virtualenvwrapper.sh'
   fi
 fi
 
@@ -270,44 +304,54 @@ fancy_echo 'Checking on Ruby installation...'
 
 append_to_file "$HOME/.gemrc" 'gem: --no-document'
 
-if command -v rbenv >/dev/null || command -v rvm >/dev/null; then
-  fancy_echo 'We recommend chruby and ruby-install over RVM or rbenv'
-else
-  if ! brew_is_installed "chruby"; then
-    fancy_echo 'Installing chruby, ruby-install, and the latest Ruby...'
-
+case "$SHELL" in
+  */fish) :
+    fancy_echo 'Installing rbenv...'
     brew bundle --file=- <<EOF
-    brew 'chruby'
-    brew 'ruby-install'
+    brew 'rbenv'
 EOF
-
-    append_to_file "$shell_file" 'source /usr/local/share/chruby/chruby.sh'
-    append_to_file "$shell_file" 'source /usr/local/share/chruby/auto.sh'
-
-    ruby-install ruby
-
-    append_to_file "$shell_file" "chruby ruby-$(latest_installed_ruby)"
-
-    switch_to_latest_ruby
-  else
-    brew bundle --file=- <<EOF
-    brew 'chruby'
-    brew 'ruby-install'
-EOF
-    fancy_echo 'Checking if a newer version of Ruby is available...'
-    switch_to_latest_ruby
-
-    ruby-install --latest > /dev/null
-    latest_stable_ruby="$(cat < "$HOME/.cache/ruby-install/ruby/stable.txt" | tail -n1)"
-
-    if ! [ "$latest_stable_ruby" = "$(latest_installed_ruby)" ]; then
-      fancy_echo "Installing latest stable Ruby version: $latest_stable_ruby"
-      ruby-install ruby
+    append_to_file "$shell_file" "status --is-interactive; and source (rbenv init -|psub)"
+    ;;
+  *) :
+    if command -v rbenv >/dev/null || command -v rvm >/dev/null; then
+      fancy_echo 'We recommend chruby and ruby-install over RVM or rbenv'
     else
-      fancy_echo 'You have the latest version of Ruby'
+      if ! brew_is_installed "chruby"; then
+        fancy_echo 'Installing chruby, ruby-install, and the latest Ruby...'
+
+        brew bundle --file=- <<EOF
+        brew 'chruby'
+        brew 'ruby-install'
+EOF
+
+        append_to_posix_shell_file 'source /usr/local/share/chruby/chruby.sh'
+        append_to_posix_shell_file 'source /usr/local/share/chruby/auto.sh'
+
+        ruby-install ruby
+
+        append_to_posix_shell_file "chruby ruby-$(latest_installed_ruby)"
+
+        switch_to_latest_ruby
+      else
+        brew bundle --file=- <<EOF
+        brew 'chruby'
+        brew 'ruby-install'
+EOF
+        fancy_echo 'Checking if a newer version of Ruby is available...'
+        switch_to_latest_ruby
+
+        ruby-install --latest > /dev/null
+        latest_stable_ruby="$(cat < "$HOME/.cache/ruby-install/ruby/stable.txt" | tail -n1)"
+
+        if ! [ "$latest_stable_ruby" = "$(latest_installed_ruby)" ]; then
+          fancy_echo "Installing latest stable Ruby version: $latest_stable_ruby"
+          ruby-install ruby
+        else
+          fancy_echo 'You have the latest version of Ruby'
+        fi
+      fi
     fi
-  fi
-fi
+esac
 
 fancy_echo 'Updating Rubygems...'
 gem update --system

--- a/mac
+++ b/mac
@@ -31,15 +31,8 @@ append_to_file() {
   fi
 }
 
-append_to_posix_shell_file() {
-  case "$SHELL" in
-    */fish) :
-      fancy_echo "Not appending %s to config.fish" "$1"
-      ;;
-    *)
-      append_to_file "$shell_file" "$1"
-      ;;
-  esac
+append_to_shell_file() {
+  append_to_file "$shell_file" "$1"
 }
 
 create_and_set_shell_file() {
@@ -151,10 +144,17 @@ switch_to_latest_ruby() {
   chruby "ruby-$(latest_installed_ruby)"
 }
 
-append_to_file "$shell_file" "alias laptop='bash <(curl -s https://raw.githubusercontent.com/18F/laptop/master/laptop)'"
+append_to_shell_file "alias laptop='bash <(curl -s https://raw.githubusercontent.com/18F/laptop/master/laptop)'"
 
 # shellcheck disable=SC2016
-append_to_posix_shell_file 'export PATH="$HOME/.bin:$PATH"'
+case "$SHELL" in
+  */fish) :
+    append_to_shell_file 'set -xg PATH $HOME/.bin $PATH'
+    ;;
+  *) :
+    append_to_shell_file 'export PATH="$HOME/.bin:$PATH"'
+    ;;
+esac
 
 if ! command -v brew >/dev/null; then
   fancy_echo "Installing Homebrew ..."
@@ -162,7 +162,14 @@ if ! command -v brew >/dev/null; then
       'https://raw.githubusercontent.com/Homebrew/install/master/install' | ruby
 
     # shellcheck disable=SC2016
-    append_to_posix_shell_file 'export PATH="/usr/local/bin:$PATH"'
+    case "$SHELL" in
+      */fish) :
+        # noop, fish ships with /usr/local/bin in a good spot in the path
+        ;;
+      *) :
+        append_to_shell_file 'export PATH="/usr/local/bin:$PATH"'
+        ;;
+    esac
 else
   fancy_echo "Homebrew already installed. Skipping ..."
 fi
@@ -209,7 +216,7 @@ case "$SHELL" in
     hub alias fish > "$HOME/.config/fish/functions/git.fish"
     ;;
   *) :
-    append_to_posix_shell_file 'eval "$(hub alias -s)"'
+    append_to_shell_file 'eval "$(hub alias -s)"'
     ;;
 esac
 
@@ -261,14 +268,14 @@ if ! brew_is_installed "python3"; then
 EOF
   case "$SHELL" in
     */fish) :
-      append_to_file "$shell_file" "status --is-interactive; and source (pyenv init -|psub)"
-      append_to_file "$shell_file" "status --is-interactive; and source (pyenv virtualenv-init -|psub)"
+      append_to_shell_file "status --is-interactive; and source (pyenv init -|psub)"
+      append_to_shell_file "status --is-interactive; and source (pyenv virtualenv-init -|psub)"
       ;;
     *) :
       # shellcheck disable=SC2016
-      append_to_posix_shell_file 'if which pyenv > /dev/null; then eval "$(pyenv init -)"; fi'
+      append_to_shell_file 'if which pyenv > /dev/null; then eval "$(pyenv init -)"; fi'
       # shellcheck disable=SC2016
-      append_to_posix_shell_file 'if which pyenv-virtualenv-init > /dev/null; then eval "$(pyenv virtualenv-init -)"; fi'
+      append_to_shell_file 'if which pyenv-virtualenv-init > /dev/null; then eval "$(pyenv virtualenv-init -)"; fi'
   esac
 
   # pyenv currently doesn't have a convenience version to use, e.g., "latest",
@@ -288,11 +295,18 @@ fi
 
 if ! brew_is_installed "pyenv-virtualenvwrapper"; then
   if ! pip3 list | ag "virtualenvwrapper" > /dev/null; then
-    fancy_echo 'Installing virtualenvwrapper...'
-    pip3 install virtualenvwrapper
-    append_to_posix_shell_file 'export VIRTUALENVWRAPPER_PYTHON=/usr/local/bin/python3'
-    append_to_posix_shell_file 'export VIRTUALENVWRAPPER_VIRTUALENV=/usr/local/bin/virtualenv'
-    append_to_posix_shell_file 'source /usr/local/bin/virtualenvwrapper.sh'
+    case "$SHELL" in
+      */fish) :
+        fancy_echo "virtualenvwrapper is not compatible with fish"
+        ;;
+      *) :
+        fancy_echo 'Installing virtualenvwrapper...'
+        pip3 install virtualenvwrapper
+        append_to_shell_file 'export VIRTUALENVWRAPPER_PYTHON=/usr/local/bin/python3'
+        append_to_shell_file 'export VIRTUALENVWRAPPER_VIRTUALENV=/usr/local/bin/virtualenv'
+        append_to_shell_file 'source /usr/local/bin/virtualenvwrapper.sh'
+        ;;
+    esac
   fi
 fi
 
@@ -309,7 +323,7 @@ case "$SHELL" in
     brew bundle --file=- <<EOF
     brew 'rbenv'
 EOF
-    append_to_file "$shell_file" "status --is-interactive; and source (rbenv init -|psub)"
+    append_to_shell_file "status --is-interactive; and source (rbenv init -|psub)"
     # rbenv currently doesn't have a convenience version to use, e.g., "latest",
     # so we check for the latest version against Homebrew instead.
     latest_ruby="$(brew info ruby | egrep -o "\d+\.\d+\.\d+" | head -1)"
@@ -331,12 +345,12 @@ EOF
         brew 'ruby-install'
 EOF
 
-        append_to_posix_shell_file 'source /usr/local/share/chruby/chruby.sh'
-        append_to_posix_shell_file 'source /usr/local/share/chruby/auto.sh'
+        append_to_shell_file 'source /usr/local/share/chruby/chruby.sh'
+        append_to_shell_file 'source /usr/local/share/chruby/auto.sh'
 
         ruby-install ruby
 
-        append_to_posix_shell_file "chruby ruby-$(latest_installed_ruby)"
+        append_to_shell_file "chruby ruby-$(latest_installed_ruby)"
 
         switch_to_latest_ruby
       else


### PR DESCRIPTION
Adds support for using fish as the developer shell (#164).

Changes from the zsh/bash setup:

* `rbenv` for ruby version management.

Rough edges:

* `nvm` is installed, but doesn't work in fish without a wrapper. A link to a potential wrapper is provided during the run.