### PR TITLE
Enable MacOS and laptop script testing in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
 
   test-macos:
     macos:
-      xcode: "10.1"
+      xcode: "10.1.0"
     steps:
       - checkout
       - run:
@@ -39,5 +39,4 @@ workflows:
     jobs:
       - lint
       - test-ubuntu
-      # TODO waiting on purchase approval to enable macos builds
-      #- test-macos
+      - test-macos

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
       - run: shellcheck mac
       - run: shellcheck seekrets-install
 
-  test-ubuntu:
+  test-seekrets-ubuntu:
     machine: yes
     steps:
       - checkout
@@ -18,7 +18,7 @@ jobs:
       - run: cat seekrets-install | bash -
       - run: bats test/seekrets.bats
 
-  test-macos:
+  test-seekrets-macos:
     macos:
       xcode: "10.1.0"
     steps:
@@ -32,11 +32,25 @@ jobs:
       - run: cat seekrets-install | bash -
       - run: bats test/seekrets.bats
 
+  test-laptop:
+    macos:
+      xcode: "10.1.0"
+    steps:
+      - checkout
+      - run:
+          name: install bats
+          command: |
+            git clone https://github.com/bats-core/bats-core.git /tmp/bats
+            cd /tmp/bats
+            sudo ./install.sh /usr/local
+      - run: bash ./mac
+
 
 workflows:
   version: 2
   commit:
     jobs:
       - lint
-      - test-ubuntu
-      - test-macos
+      - test-seekrets-ubuntu
+      - test-seekrets-macos
+      - test-laptop


### PR DESCRIPTION
We've procured a MacOS plan on CircleCI, so this enabled testing for the seekrets script as well as the laptop/mac script.

Please double check that this [script output](https://circleci.com/gh/18F/laptop/124) looks correct. CI runs the script and asserts it exits 0. Is that sufficient?