### PR TITLE
Update bats readme to point to bats-core

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -1,8 +1,8 @@
 ## Local BATS documentation
 
 Testing for the `git-seekrets` is performed via a testing framework called
-[BATS](https://github.com/sstephenson/bats).  To create an associated test
-for new seekrets rulesets, it is necessary to install BATS.   More
+[BATS](https://github.com/bats-core/bats-core). To create an associated test
+for new seekrets rulesets, it is necessary to install BATS. More
 information on installation is located in the `seekrets.bats` script.
 
 Below is an example invocation for running the seekrets test with
@@ -10,13 +10,12 @@ BATS:
 
         bats --tap seekrets.bat
 
-
 More information on the TAP format is available at the following
 address http://testanything.org/
 
 ## Adding new tests
 
-The tests for `git-seekret` are located in `seekrets.bats`.  The following would describe a test case for a matching a new secret:
+The tests for `git-seekret` are located in `seekrets.bats`. The following would describe a test case for a matching a new secret:
 
 ```shell
 @test "git-seekrets finds a new type of secret"
@@ -25,7 +24,7 @@ The tests for `git-seekret` are located in `seekrets.bats`.  The following would
 }
 ```
 
-Helper and test function definitons are located in `test_helper.bash` in the test directory of this repository.  An associated test function for the above example test could be structured like:
+Helper and test function definitons are located in `test_helper.bash` in the test directory of this repository. An associated test function for the above example test could be structured like:
 
 ```shell
 addFileWithNewTypeOfSecret() {
@@ -46,5 +45,3 @@ A test case for a false positive match (with associated test function in `test_h
     [ $status -eq 0 ]
 }
 ```
-
-

--- a/test/seekrets.bats
+++ b/test/seekrets.bats
@@ -13,7 +13,7 @@
 #
 #     * homebrew method
 #
-#              brew install bats
+#              brew install bats-core
 #
 # Running Tests:
 #


### PR DESCRIPTION
The old repo at [sstephenson/bats](/sstephenson/bats) is no longer maintained. The preferred repo is now [bats-core](/bats-core/bats-core), and the brew command is now `brew install bats-core`.  PR updates the test README along with the comments in the `seekrets.bats` file referring to the old bats.