### PR TITLE
Use zlib from brew for building Python

### DIFF
--- a/mac
+++ b/mac
@@ -265,6 +265,7 @@ fancy_echo 'Checking on Python installation...'
 
 if ! brew_is_installed "python3"; then
   brew bundle --file=- <<EOF
+  brew 'zlib'
   brew 'pyenv'
   brew 'pyenv-virtualenv'
   brew 'pyenv-virtualenvwrapper'
@@ -286,6 +287,12 @@ EOF
   latest_python_3="$(brew info python3 | grep -E -o "3\.\d+\.\d+" | head -1)"
 
   if ! pyenv versions | ag "$latest_python_3" > /dev/null; then
+    # Starting with macOS 10.14 (Mojave), the header files for system libraries
+    # have been moved. Rather than hack the header paths based on OS version,
+    # just install zlib with brew and build against that directly for now.
+    brew install zlib
+    export LDFLAGS="-L/usr/local/opt/zlib/lib"
+    export CPPFLAGS="-I/usr/local/opt/zlib/include"
     pyenv install "$latest_python_3"
     pyenv global "$latest_python_3"
     pyenv rehash


### PR DESCRIPTION
Starting with macOS 10.14, the path to standard header file has been moved.  The build tools bundled with the macOS SDK look for headers in the new path, but 3rd-party build tools continue to look for the files in the standard paths.  That includes `pyenv`, which now fails to build because it can't find zlib headers.

[relevant pyenv issue](https://github.com/pyenv/pyenv/issues/1219)

[Xcode 10 release notes](https://developer.apple.com/documentation/xcode_release_notes/xcode_10_release_notes)

Rather than hack in the paths to the headers based on the OS version, this PR installs zlib with brew and links to that for building with pyenv.

Closes #180 