### PR TITLE
Remove invalid option for brew tap

### DIFF
--- a/mac
+++ b/mac
@@ -114,7 +114,7 @@ brew_is_installed() {
 }
 
 tap_is_installed() {
-  brew tap -1 | grep -Fqx "$1"
+  brew tap | grep -Fqx "$1"
 }
 
 gem_install_or_update() {


### PR DESCRIPTION
Eliminates a warning triggered by the brew tap command being passed an argument of "-1".  Note: this should result in the following lines working again, which will now uninstall caskroom/versions for anyone who already has it installed and reruns the script.

Someone with a little more familiarity than me could better judge whether we want to do that or whether we'd rather delete these lines:

```
if tap_is_installed 'caskroom/versions'; then
  brew untap caskroom/versions
fi
```