### PR TITLE
Enable git-seekrets rules globally; Add audit fix

### DIFF
--- a/seekrets-install
+++ b/seekrets-install
@@ -119,6 +119,7 @@ if toolminversion git 2.9.1; then
   git config --global core.hooksPath "${HOME}/.git-support/hooks"
   git seekret --global config --init
   # Activate all installed rules
+  git config --global gitseekret.rulespath $SEEKRET_RULES_PATH
   git seekret --global rules --enable-all
   git seekret --global hook --enable-all
 

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -1,5 +1,6 @@
 #!/usr/bin/env bats
 
+# Usage: `export LOCAL_AUDIT="anything"` to use any rules in place locally.
 REPO_PATH=$(mktemp -d "${BATS_TMPDIR}/gittest.XXXXXX")
 LOCAL_SEEKRETS="$(dirname $BATS_TEST_DIRNAME)/seekret-rules"
 
@@ -20,6 +21,9 @@ fi
 
 setupGitRepo() {
     git init "${REPO_PATH}"
+}
+
+setupLocalGitSeekrets() {
     git config --local gitseekret.rulespath "$LOCAL_SEEKRETS"
     git config --global gitseekret.rulespath "$LOCAL_SEEKRETS"
     (cd "${REPO_PATH}" && \
@@ -242,6 +246,9 @@ addFileWithSlackAPIToken() {
 
 setup() {
     setupGitRepo
+    if [ -z "$LOCAL_AUDIT" ]; then
+      setupLocalGitSeekrets
+    fi
 }
 
 teardown() {


### PR DESCRIPTION
This pairs with https://github.com/18F/cg-scripts/pull/114 to enable all these tests to run on a local system to test that git-seekrets is installed with rules enabled globally.

I wish there were a better way to keep git-seekrets from disabling rules locally, or to find such instances, but that's later work.

Once this is merged, the `cg-scripts` PR needs the `$BRANCH` variable changed to `master`