### PR TITLE
Remove cloudapp since blocked on VPN.

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -13,7 +13,6 @@ tap 'cloudfoundry/homebrew-tap'
 brew 'cf-cli'
 
 cask 'chromedriver'
-cask 'cloudapp'
 cask 'docker'
 cask 'slack'
 

--- a/README.md
+++ b/README.md
@@ -157,7 +157,6 @@ What it sets up
 
 * [ChromeDriver] for headless website testing
 * [chruby] for managing [Ruby] versions (or, when using a fish shell, [rbenv])
-* [CloudApp] for sharing screenshots and making an animated GIF from a video
 * [Cloud Foundry CLI] for command line access to 18F's Cloud Foundry-based application platform
 * [Docker] for all your containerization needs
 * [git-seekret] for preventing you from committing passwords and other sensitive information to a git repository
@@ -178,7 +177,6 @@ What it sets up
 [Bundler]: http://bundler.io/
 [ChromeDriver]: http://chromedriver.chromium.org/
 [chruby]: https://github.com/postmodern/chruby
-[CloudApp]: http://getcloudapp.com/
 [Cloud Foundry CLI]: https://github.com/cloudfoundry/cli
 [Docker]: https://www.docker.com/
 [git-seekret]: https://github.com/18F/git-seekret


### PR DESCRIPTION
Removing CloudApp from the Brewfile and README.md. The download fails when connected to the VPN because [http://getcloudapp.com](http://getcloudapp.com) is now blocked. No longer approved software? 