### PR TITLE
Update to bash-based Homebrew install

### DIFF
--- a/mac
+++ b/mac
@@ -154,7 +154,7 @@ esac
 
 if ! command -v brew >/dev/null; then
   fancy_echo "Installing Homebrew ..."
-  /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 
   case "$SHELL" in
     */fish) :


### PR DESCRIPTION
Per attempting to install via ruby:
```
Warning: The Ruby Homebrew installer is now deprecated and has been rewritten in
Bash. Please migrate to the following command:
  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
```