### PR TITLE
Remove rbenv and suggest chruby-fish

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ What it sets up
 ---------------
 
 * [ChromeDriver] for headless website testing
-* [chruby] for managing [Ruby] versions (or, when using a fish shell, [rbenv])
+* [chruby] for managing [Ruby] versions
 * [Cloud Foundry CLI] for command line access to 18F's Cloud Foundry-based application platform
 * [Docker] for all your containerization needs
 * [git-seekret] for preventing you from committing passwords and other sensitive information to a git repository
@@ -189,7 +189,6 @@ What it sets up
 [NPM]: https://www.npmjs.org/
 [Python]: https://www.python.org/
 [pyenv]: https://github.com/yyuu/pyenv/
-[rbenv]: https://github.com/rbenv/rbenv
 [Ruby]: https://www.ruby-lang.org/en/
 [ruby-install]: https://github.com/postmodern/ruby-install
 [Slack]: https://slack.com/

--- a/mac
+++ b/mac
@@ -320,22 +320,8 @@ fancy_echo 'Checking on Ruby installation...'
 append_to_file "$HOME/.gemrc" 'gem: --no-document'
 
 case "$SHELL" in
-  # chruby is recommended by the org, but it doesn't work in fish, so in a
-  # fish shell, use rbenv
   */fish) :
-    fancy_echo 'Installing rbenv...'
-    brew bundle --file=- <<EOF
-    brew 'rbenv'
-EOF
-    append_to_shell_file "status --is-interactive; and source (rbenv init -|psub)"
-    # rbenv currently doesn't have a convenience version to use, e.g., "latest",
-    # so we check for the latest version against Homebrew instead.
-    latest_ruby="$(brew info ruby | grep -E -o "\d+\.\d+\.\d+" | head -1)"
-    if ! rbenv versions | ag "$latest_ruby" > /dev/null; then
-      rbenv install "$latest_ruby"
-      rbenv global "$latest_ruby"
-      eval "$(rbenv init - bash)"
-    fi
+    fancy_echo "We recommend following the steps at https://github.com/JeanMertz/chruby-fish to install chruby in fish"
     ;;
 
   # For all other shells, install chruby as long as rbenv is not installed


### PR DESCRIPTION
I've had good success with https://github.com/JeanMertz/chruby-fish, and figure it could be an opportunity to remove more of the rbenv/rvm parts here. I copied the line from https://github.com/18F/laptop/blob/c57d38af51e8c22b1f813443ac308115d399d2d1/mac#L222 as it seemed similar enough 🙂 